### PR TITLE
LPS-99587 Add addUserWithWorkflow tests on null prerequisites

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1679,8 +1679,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			User user = _userLocalService.updatePassword(
 				userId, password, password, passwordReset, true);
 
-			if (!passwordGenerated) {
-				user.setDigest(user.getDigest(password));
+			if (passwordGenerated) {
+				user.setDigest(StringPool.BLANK);
 			}
 
 			user.setPasswordModifiedDate(modifiedDate);

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserSetDigestTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserSetDigestTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.user.service.test;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jesse Yeh
+ */
+public class UserSetDigestTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		_user = _userLocalService.createUser(RandomTestUtil.nextLong());
+		_emailAddress =
+			RandomTestUtil.randomString() + RandomTestUtil.nextLong() +
+				"@liferay.com";
+	}
+
+	@Test
+	public void testSetDigestAfterScreenNameAndEmailAddress() throws Exception {
+		_user.setScreenName(RandomTestUtil.randomString());
+		_user.setEmailAddress(_emailAddress);
+
+		_user.setDigest(_user.getDigest(RandomTestUtil.randomString()));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSetDigestBeforeScreenNameAndEmailAddress()
+		throws Exception {
+
+		_user.setDigest(_user.getDigest(RandomTestUtil.randomString()));
+
+		_user.setScreenName(RandomTestUtil.randomString());
+		_user.setEmailAddress(_emailAddress);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSetEmailAndDigestBeforeScreenName() throws Exception {
+		_user.setEmailAddress(_emailAddress);
+
+		_user.setDigest(_user.getDigest(RandomTestUtil.randomString()));
+
+		_user.setScreenName(RandomTestUtil.randomString());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSetScreenNameAndDigestBeforeEmailAddress()
+		throws Exception {
+
+		_user.setScreenName(RandomTestUtil.randomString());
+
+		_user.setDigest(_user.getDigest(RandomTestUtil.randomString()));
+
+		_user.setEmailAddress(_emailAddress);
+	}
+
+	@Inject
+	private static UserLocalService _userLocalService;
+
+	private String _emailAddress;
+	private User _user;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4853,7 +4853,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.setPasswordModifiedDate(new Date());
 		}
 
-		user.setDigest(StringPool.BLANK);
+		user.setDigest(user.getDigest(password1));
 		user.setGraceLoginCount(0);
 
 		if (!silentUpdate) {

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1038,9 +1038,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.setPasswordReset(false);
 		}
 
-		user.setDigest(user.getDigest(password1));
 		user.setScreenName(screenName);
 		user.setEmailAddress(emailAddress);
+
+		user.setDigest(user.getDigest(password1));
+
 		user.setFacebookId(facebookId);
 
 		Long ldapServerId = null;

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1038,7 +1038,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.setPasswordReset(false);
 		}
 
-		user.setDigest(StringPool.BLANK);
+		user.setDigest(user.getDigest(password1));
 		user.setScreenName(screenName);
 		user.setEmailAddress(emailAddress);
 		user.setFacebookId(facebookId);
@@ -4929,7 +4929,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setPasswordEncrypted(passwordEncrypted);
 		user.setPasswordReset(passwordReset);
 		user.setPasswordModifiedDate(passwordModifiedDate);
-		user.setDigest(StringPool.BLANK);
+		user.setDigest(user.getDigest(password));
 
 		userPersistence.update(user);
 
@@ -5208,7 +5208,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			password = newPassword1;
 
-			user.setDigest(StringPool.BLANK);
+			user.setDigest(user.getDigest(password));
 		}
 
 		if (user.getContactId() <= 0) {


### PR DESCRIPTION
## Problem

This is a continuation of this [pull request](https://github.com/wanderlast/liferay-portal/pull/29), which is a continuation of this [pull request](https://github.com/brianchandotcom/liferay-portal/pull/79098) for [LPS-99587](https://issues.liferay.com/browse/LPS-99587). This pull request adds additional tests for `addUserWithWorkflow` to check that the user digest is set after the prerequisites (`emailAddress` and `screenName`) are set.

## Solution

In the event that the user digest is set before the prerequisites, an `IllegalStateException` will be thrown. We account for this behavior by introducing a positive test via `testAddUserWithWorkflowWithPrerequisites`. To simulate the user digest being set prior to the prerequisites, `null` is passed in place of the `screenName` and `emailAddress` arguments; additional tests check that the appropriate exceptions for an invalid `screenName` and/or `emailAddress` are raised.