### PR TITLE
LPS-104754 Account for multiple statuses in item selectors to maintain 7.2 WCD parity

### DIFF
--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/info/item/criterion/InfoItemItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/info/item/criterion/InfoItemItemSelectorCriterion.java
@@ -15,6 +15,7 @@
 package com.liferay.item.selector.criteria.info.item.criterion;
 
 import com.liferay.item.selector.BaseItemSelectorCriterion;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 /**
@@ -34,8 +35,17 @@ public class InfoItemItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _mimeTypes;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getStatuses()}
+	 */
+	@Deprecated
 	public int getStatus() {
 		return _status;
+	}
+
+	public int[] getStatuses() {
+		return _statuses;
 	}
 
 	public void setItemSubtype(String itemSubtype) {
@@ -50,13 +60,38 @@ public class InfoItemItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_mimeTypes = mimeTypes;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setStatuses(int...)}
+	 */
+	@Deprecated
 	public void setStatus(int status) {
 		_status = status;
+		setStatuses(status);
+	}
+
+	public void setStatuses(int... statuses) {
+		if ((statuses.length > 1) &&
+			ArrayUtil.contains(statuses, WorkflowConstants.STATUS_ANY)) {
+
+			_statuses = new int[] {WorkflowConstants.STATUS_ANY};
+		}
+		else {
+			_statuses = statuses;
+		}
 	}
 
 	private String _itemSubtype;
 	private String _itemType;
 	private String[] _mimeTypes;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #_statuses}
+	 */
+	@Deprecated
 	private int _status = WorkflowConstants.STATUS_APPROVED;
+
+	private int[] _statuses = {getStatus()};
 
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
@@ -119,6 +119,11 @@ public interface JournalFolderService extends BaseService {
 		int start, int end, OrderByComparator<?> obc);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Object> getFoldersAndArticles(
+		long groupId, long userId, long folderId, int[] statuses, Locale locale,
+		int start, int end, OrderByComparator<?> obc);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getFoldersAndArticlesCount(
 		long groupId, List<Long> folderIds, int status);
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
@@ -159,6 +159,15 @@ public class JournalFolderServiceUtil {
 			groupId, userId, folderId, status, locale, start, end, obc);
 	}
 
+	public static java.util.List<Object> getFoldersAndArticles(
+		long groupId, long userId, long folderId, int[] statuses,
+		java.util.Locale locale, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<?> obc) {
+
+		return getService().getFoldersAndArticles(
+			groupId, userId, folderId, statuses, locale, start, end, obc);
+	}
+
 	public static int getFoldersAndArticlesCount(
 		long groupId, java.util.List<Long> folderIds, int status) {
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
@@ -167,6 +167,16 @@ public class JournalFolderServiceWrapper
 	}
 
 	@Override
+	public java.util.List<Object> getFoldersAndArticles(
+		long groupId, long userId, long folderId, int[] statuses,
+		java.util.Locale locale, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<?> obc) {
+
+		return _journalFolderService.getFoldersAndArticles(
+			groupId, userId, folderId, statuses, locale, start, end, obc);
+	}
+
+	@Override
 	public int getFoldersAndArticlesCount(
 		long groupId, java.util.List<Long> folderIds, int status) {
 

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -522,8 +522,9 @@ public class JournalContentDisplayContext {
 
 		infoItemItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new JournalArticleItemSelectorReturnType());
-		infoItemItemSelectorCriterion.setStatus(
-			WorkflowConstants.STATUS_APPROVED);
+		infoItemItemSelectorCriterion.setStatuses(
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_SCHEDULED);
 
 		ItemSelector itemSelector = (ItemSelector)_portletRequest.getAttribute(
 			JournalWebKeys.ITEM_SELECTOR);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
@@ -604,6 +604,39 @@ public class JournalFolderServiceHttp {
 		}
 	}
 
+	public static java.util.List<Object> getFoldersAndArticles(
+		HttpPrincipal httpPrincipal, long groupId, long userId, long folderId,
+		int[] statuses, java.util.Locale locale, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<?> obc) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalFolderServiceUtil.class, "getFoldersAndArticles",
+				_getFoldersAndArticlesParameterTypes16);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, userId, folderId, statuses, locale, start,
+				end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return (java.util.List<Object>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static int getFoldersAndArticlesCount(
 		HttpPrincipal httpPrincipal, long groupId,
 		java.util.List<Long> folderIds, int status) {
@@ -611,7 +644,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes16);
+				_getFoldersAndArticlesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderIds, status);
@@ -641,7 +674,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes17);
+				_getFoldersAndArticlesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -671,7 +704,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes18);
+				_getFoldersAndArticlesCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -702,7 +735,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes19);
+				_getFoldersAndArticlesCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, folderId, status);
@@ -732,7 +765,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes20);
+				_getFoldersCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId);
@@ -763,7 +796,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes21);
+				_getFoldersCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, status);
@@ -794,7 +827,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes22);
+				_getSubfolderIdsParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderIds, groupId, folderId, recurse);
@@ -821,7 +854,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes23);
+				_getSubfolderIdsParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, recurse);
@@ -853,7 +886,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolder",
-				_moveFolderParameterTypes24);
+				_moveFolderParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -892,7 +925,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolderFromTrash",
-				_moveFolderFromTrashParameterTypes25);
+				_moveFolderFromTrashParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -930,7 +963,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolderToTrash",
-				_moveFolderToTrashParameterTypes26);
+				_moveFolderToTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -968,7 +1001,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "restoreFolderFromTrash",
-				_restoreFolderFromTrashParameterTypes27);
+				_restoreFolderFromTrashParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1009,7 +1042,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "searchDDMStructures",
-				_searchDDMStructuresParameterTypes28);
+				_searchDDMStructuresParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, folderId, restrictionType,
@@ -1049,7 +1082,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "subscribe",
-				_subscribeParameterTypes29);
+				_subscribeParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1083,7 +1116,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes30);
+				_unsubscribeParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1120,7 +1153,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes31);
+				_updateFolderParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, parentFolderId, name, description,
@@ -1163,7 +1196,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes32);
+				_updateFolderParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, parentFolderId, name, description,
@@ -1256,64 +1289,70 @@ public class JournalFolderServiceHttp {
 			java.util.Locale.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes16 = new Class[] {
-			long.class, java.util.List.class, int.class
+	private static final Class<?>[] _getFoldersAndArticlesParameterTypes16 =
+		new Class[] {
+			long.class, long.class, long.class, int[].class,
+			java.util.Locale.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
 		_getFoldersAndArticlesCountParameterTypes17 = new Class[] {
-			long.class, long.class
+			long.class, java.util.List.class, int.class
 		};
 	private static final Class<?>[]
 		_getFoldersAndArticlesCountParameterTypes18 = new Class[] {
-			long.class, long.class, int.class
+			long.class, long.class
 		};
 	private static final Class<?>[]
 		_getFoldersAndArticlesCountParameterTypes19 = new Class[] {
+			long.class, long.class, int.class
+		};
+	private static final Class<?>[]
+		_getFoldersAndArticlesCountParameterTypes20 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getFoldersCountParameterTypes20 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes21 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _getFoldersCountParameterTypes22 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes22 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes23 =
 		new Class[] {
 			java.util.List.class, long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes23 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes24 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _moveFolderParameterTypes24 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes25 = new Class[] {
 		long.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _moveFolderFromTrashParameterTypes25 =
+	private static final Class<?>[] _moveFolderFromTrashParameterTypes26 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveFolderToTrashParameterTypes26 =
+	private static final Class<?>[] _moveFolderToTrashParameterTypes27 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreFolderFromTrashParameterTypes27 =
+	private static final Class<?>[] _restoreFolderFromTrashParameterTypes28 =
 		new Class[] {long.class};
-	private static final Class<?>[] _searchDDMStructuresParameterTypes28 =
+	private static final Class<?>[] _searchDDMStructuresParameterTypes29 =
 		new Class[] {
 			long.class, long[].class, long.class, int.class, String.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes29 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes30 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _unsubscribeParameterTypes30 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes31 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _updateFolderParameterTypes31 =
+	private static final Class<?>[] _updateFolderParameterTypes32 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes32 =
+	private static final Class<?>[] _updateFolderParameterTypes33 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			long[].class, int.class, boolean.class,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -212,6 +212,18 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 	}
 
 	@Override
+	public List<Object> getFoldersAndArticles(
+		long groupId, long userId, long folderId, int[] statuses, Locale locale,
+		int start, int end, OrderByComparator<?> obc) {
+
+		QueryDefinition<?> queryDefinition = new QueryDefinition<>(
+			statuses, userId, true, start, end, (OrderByComparator<Object>)obc);
+
+		return journalFolderFinder.filterFindF_A_ByG_F_L(
+			groupId, folderId, locale, queryDefinition);
+	}
+
+	@Override
 	public int getFoldersAndArticlesCount(
 		long groupId, List<Long> folderIds, int status) {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
@@ -342,7 +342,10 @@ public class JournalFolderFinderImpl
 			QueryPos qPos = QueryPos.getInstance(q);
 
 			qPos.add(groupId);
-			qPos.add(queryDefinition.getStatus());
+
+			for (int status : queryDefinition.getStatuses()) {
+				qPos.add(status);
+			}
 
 			if (folderId >= 0) {
 				qPos.add(folderId);
@@ -355,7 +358,9 @@ public class JournalFolderFinderImpl
 				qPos.add(WorkflowConstants.STATUS_IN_TRASH);
 			}
 
-			qPos.add(queryDefinition.getStatus());
+			for (int status : queryDefinition.getStatuses()) {
+				qPos.add(status);
+			}
 
 			if (folderId >= 0) {
 				qPos.add(folderId);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -260,7 +260,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 
 			List results = JournalFolderServiceUtil.getFoldersAndArticles(
 				_themeDisplay.getScopeGroupId(), 0, _getFolderId(),
-				_infoItemItemSelectorCriterion.getStatus(),
+				_infoItemItemSelectorCriterion.getStatuses(),
 				_themeDisplay.getLocale(), articleSearchContainer.getStart(),
 				articleSearchContainer.getEnd(), folderOrderByComparator);
 

--- a/modules/apps/portal/portal-dao-orm-custom-sql-impl/src/main/java/com/liferay/portal/dao/orm/custom/sql/internal/CustomSQLImpl.java
+++ b/modules/apps/portal/portal-dao-orm-custom-sql-impl/src/main/java/com/liferay/portal/dao/orm/custom/sql/internal/CustomSQLImpl.java
@@ -169,21 +169,15 @@ public class CustomSQLImpl implements CustomSQL {
 			tableName = tableName.concat(StringPool.PERIOD);
 		}
 
-		if (queryDefinition.getStatus() == WorkflowConstants.STATUS_ANY) {
+		if (ArrayUtil.contains(
+				queryDefinition.getStatuses(), WorkflowConstants.STATUS_ANY)) {
+
 			sql = StringUtil.replace(
 				sql, _STATUS_KEYWORD, _STATUS_CONDITION_EMPTY);
 		}
 		else {
-			if (queryDefinition.isExcludeStatus()) {
-				sql = StringUtil.replace(
-					sql, _STATUS_KEYWORD,
-					tableName.concat(_STATUS_CONDITION_INVERSE));
-			}
-			else {
-				sql = StringUtil.replace(
-					sql, _STATUS_KEYWORD,
-					tableName.concat(_STATUS_CONDITION_DEFAULT));
-			}
+			sql = StringUtil.replace(
+				sql, _STATUS_KEYWORD, _getStatusesSQL(queryDefinition));
 		}
 
 		if (queryDefinition.getOwnerUserId() > 0) {
@@ -900,6 +894,30 @@ public class CustomSQLImpl implements CustomSQL {
 		}
 
 		return new CustomSQLContainer(classLoader, sourceURL);
+	}
+
+	private String _getStatusesSQL(QueryDefinition<?> queryDefinition) {
+		String prefix = "";
+		String statusCondition;
+
+		if (queryDefinition.isExcludeStatuses()) {
+			statusCondition = _STATUS_CONDITION_INVERSE;
+		}
+		else {
+			statusCondition = _STATUS_CONDITION_DEFAULT;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		int[] statuses = queryDefinition.getStatuses();
+
+		for (int i = 0; i < statuses.length; i++) {
+			sb.append(prefix);
+			prefix = queryDefinition.isExcludeStatuses() ? " AND " : " OR ";
+			sb.append(statusCondition);
+		}
+
+		return sb.toString();
 	}
 
 	private void _read(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/QueryDefinition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/QueryDefinition.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.dao.orm;
 
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.TableNameOrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -95,6 +96,25 @@ public class QueryDefinition<T> {
 		setOrderByComparator(orderByComparator);
 	}
 
+	public QueryDefinition(
+		int[] statuses, long ownerUserId, boolean includeOwner, int start,
+		int end, OrderByComparator<T> orderByComparator) {
+
+		if (ArrayUtil.contains(statuses, WorkflowConstants.STATUS_ANY)) {
+			setStatuses(new int[] {WorkflowConstants.STATUS_IN_TRASH}, true);
+		}
+		else {
+			setStatuses(statuses);
+		}
+
+		_ownerUserId = ownerUserId;
+		_includeOwner = includeOwner;
+		_start = start;
+		_end = end;
+
+		setOrderByComparator(orderByComparator);
+	}
+
 	public Serializable getAttribute(String name) {
 		if (_attributes == null) {
 			return null;
@@ -131,12 +151,30 @@ public class QueryDefinition<T> {
 		return _start;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getStatuses()}
+	 */
+	@Deprecated
 	public int getStatus() {
 		return _status;
 	}
 
+	public int[] getStatuses() {
+		return _statuses;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #isExcludeStatuses()}
+	 */
+	@Deprecated
 	public boolean isExcludeStatus() {
 		return _excludeStatus;
+	}
+
+	public boolean isExcludeStatuses() {
+		return _excludeStatuses;
 	}
 
 	public boolean isIncludeOwner() {
@@ -175,22 +213,58 @@ public class QueryDefinition<T> {
 		_start = start;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setStatuses(int...)}
+	 */
+	@Deprecated
 	public void setStatus(int status) {
 		setStatus(status, false);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setStatuses(int[], boolean)}
+	 */
+	@Deprecated
 	public void setStatus(int status, boolean exclude) {
 		_excludeStatus = exclude;
 		_status = status;
+		setStatuses(new int[] {status}, exclude);
+	}
+
+	public void setStatuses(int... statuses) {
+		setStatuses(statuses, false);
+	}
+
+	public void setStatuses(int[] statuses, boolean exclude) {
+		_excludeStatuses = exclude;
+		_statuses = statuses;
 	}
 
 	private Map<String, Serializable> _attributes;
 	private int _end = QueryUtil.ALL_POS;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #_excludeStatuses}
+	 */
+	@Deprecated
 	private boolean _excludeStatus;
+
+	private boolean _excludeStatuses;
 	private boolean _includeOwner;
 	private OrderByComparator<T> _orderByComparator;
 	private long _ownerUserId;
 	private int _start = QueryUtil.ALL_POS;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #_statuses}
+	 */
+	@Deprecated
 	private int _status = WorkflowConstants.STATUS_ANY;
+
+	private int[] _statuses = {getStatus()};
 
 }


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-104754](https://issues.liferay.com/browse/LPS-104754)**

The Web Content Display portlet only displays articles that are `STATUS_APPROVED` instead of articles that are both `STATUS_APPROVED` and `STATUS_SCHEDULED`. This is a regression from `7.2.x`.

## Analysis :nerd_face:

#### Overview

The original implementation's logic flow is summarized as follows:

1. `JournalContentDisplayContext.getItemSelectorURL()`
    * A single status is set in `InfoItemItemSelectorCriterion` and a URL is subsequently generated
2. `JournalArticleItemSelectorViewDisplayContext.getSearchContainer()`
3. `JournalFolderServiceImpl.getFoldersAndArticles()`
    * The criterion gets forwarded here and is used to construct a `QueryDefinition`
4. `JournalFolderFinderImpl.doFindF_A_ByG_F_L()`
    * The `QueryDefinition` is used to pick out the appropriate SQL queries (defined in [`default.xml`](https://github.com/jesseyeh-liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml#L621-L632)) for folders and articles
5. `CustomSQLImpl.get()`
    * The query's `[$STATUS]` keyword is replaced by the `QueryDefinition`'s status via string substitution
6. `QueryPos` values are added that correspond to each `?` in the SQL query

Our objective is to introduce multiple statuses so that the Web Content Display portlet can display articles with different statuses.

## Solution :tada:

Our solution aims to introduce multiple statuses while making as minimal of an impact to the existing codebase as possible. To that end, we initially considered packing multiple statuses into a single status via a bitmask (see alternative solution section below), but decided to shelve it in favor of a simpler, more straightforward approach.

#### `InfoItemItemSelectorCriterion`

We begin by introducing the `setStatuses()` and `getStatuses()` methods to `InfoItemItemSelectorCriterion` and by deprecating their single-status counterparts. To ease this transition, we:

1. Initialize `_statuses` as an array containing a single status defined by `getStatus()` (deprecated)
2. Call `setStatuses()` in `setStatus()` (deprecated) to maintain parity between `_statuses` and `_status` (deprecated)

In order to resolve the regression from `7.2.x`, we set the criteria statuses to `STATUS_APPROVED` and `STATUS_SCHEDULED` in `JournalContentDisplayContext.getItemSelectorURL()`.

#### `QueryDefinition`

In order to forward our multiple statuses from the criteria to `QueryDefinition`, we first update the latter to accept multiple statuses by introducing the `getStatuses()`, `setStatuses()`, and `isExcludeStatuses()` methods. Additionally, we add a new constructor which takes in an array of statuses. And as previously done in `InfoItemItemSelectorCriterion`, we take the same two steps outlined above to maintain parity between `_status` and `_statuses`.

#### Updating the SQL Query

In `CustomSQLImpl.get()`, we iterate over the statuses and join them together via `AND`s or `OR`s. We then take this string conglomerate and replace the `[$STATUS$]` keyword in the SQL query with it. We then iterate over the statuses again to get the appropriate number of `QueryPos` values to add in the filter/find method.

---

## Alternative Solution :thinking:

<details>
<summary><b>Read more</b></summary>
<br>

In an attempt to add multi-status support with minimal impact to existing code, we considered packing multiple statuses into a single status via a bitmask. Instead of passing several statuses via an array, we could instead pass them all using a single `int`.

Code sample:

```java
int statusMask = WorkflowConstants.STATUS_APPROVED | WorkflowConstants.STATUS_SCHEDULED | WorkflowConstants.STATUS_DRAFT;
infoItemItemSelectorCriterion.setStatus(statusMask);
```

In order for the above to work however, the status constants would ideally evaluate to incrementing powers of 2. Under this paradigm, we could specify `STATUS_EXPIRED`, `STATUS_DRAFT`, and `STATUS_APPROVED` with a single bitmask (`11010`), pass it as a single `int`, and decode it to get the individual statuses. Put together, this would look like:

```java
/*
STATUS_ANY = 1;
STATUS_APPROVED = 2;
STATUS_PENDING = 4;
STATUS_DRAFT = 8;
STATUS_EXPIRED = 16;
...
*/

int bitmask = STATUS_EXPIRED | STATUS_DRAFT | STATUS_APPROVED; // 11010
int statusToCheck = STATUS_DRAFT; // 01000

/* 
 * If cmp is a non-zero value, interpret the result as true; otherwise, false
 *
 *   11010
 * & 01000
 * -------
 *   01000
 *
 */
int cmp = bitmask & statusToCheck;
```

Unfortunately, the actual status values do not follow such a paradigm and instead evaluate to a linearly increasing sequence. We can work around this via a bitshift. For example:

```java
/*
STATUS_ANY = -1;
STATUS_APPROVED = 0;
STATUS_PENDING = 1;
STATUS_DRAFT = 2;
STATUS_EXPIRED = 3;
...
*/

int bitmask = 0b10100;
int statusDraftMask = (1 << STATUS_DRAFT) // 100

int cmp = (bitmask & statusDraftMask);
```

One caveat to this is, in the above example, bitshifting `1 << STATUS_ANY`, which results in an integer overflow (the `int` alone limits us to values in the range [0, 30], i.e., we would only be able to specify a total of 31 different status constants). We could implement another workaround by incrementing all constants by 1 and decrementing them later. However, this increases complexity and impedes code readability, and for those reasons, we decided to shelve and document this idea for now.
</details>