### PR TITLE
LPS-106201 Fix friendly URL navigation when clicking on the site name in the sidebar

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -31,6 +31,10 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
+page import="com.liferay.portal.kernel.model.GroupConstants" %><%@
+page import="com.liferay.portal.kernel.model.LayoutSet" %><%@
+page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.SessionClicks" %><%@
@@ -50,4 +54,9 @@ page import="java.util.Objects" %>
 
 <%
 ProductMenuDisplayContext productMenuDisplayContext = new ProductMenuDisplayContext(liferayPortletRequest, liferayPortletResponse);
+
+long guestGroupId = GroupLocalServiceUtil.getGroup(themeDisplay.getCompanyId(), GroupConstants.GUEST).getGroupId();
+LayoutSet guestLayoutSet = LayoutSetLocalServiceUtil.getLayoutSet(guestGroupId, false);
+
+String guestFriendlyURL = PortalUtil.getGroupFriendlyURL(guestLayoutSet, themeDisplay);
 %>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -27,7 +27,7 @@ String pagesTreeState = SessionClicks.get(request, "com.liferay.product.navigati
 
 		<div class="autofit-row">
 			<div class="autofit-col autofit-col-expand">
-				<a href="<%= PortalUtil.addPreservedParameters(themeDisplay, themeDisplay.getURLPortal(), false, true) %>">
+				<a href="<%= PortalUtil.addPreservedParameters(themeDisplay, guestFriendlyURL, false, true) %>">
 					<span class="company-details text-truncate">
 						<img alt="" class="company-logo" src="<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() + "&t=" + WebServerServletTokenUtil.getToken(company.getLogoId()) %>" />
 


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-106201](https://issues.liferay.com/browse/LPS-106201)**

After modifying a site's friendly URL, clicking on the site name in the sidebar results in navigation errors.

## Analysis :nerd_face:

The original implementation makes a call to `themeDisplay.getPortalURL()`, which does not take into account the friendly URL. It also contains a call to `themeDisplay.addPreservedParameters()` to maintain correct navigational behavior when impersonating other users, which was introduced by [LPS-65640](https://issues.liferay.com/browse/LPS-65640).

## Solution :tada:

Although there exists a `getDisplayURL()` method which returns the URL we need, the method also contains a call to `addPreservedParameters()` which unnecessarily adds the `p_p_id` parameter to the URL. Instead, we use `GroupLocalServiceUtil.getGroup(themeDisplay.getCompanyId(), GroupConstants.GUEST).getGroupId()` to reference the default site regardless of the current site. Using this, we are able to obtain the group ID, which we use to get the `LayoutSet` needed to construct the friendly URL.

##  Additional Notes :memo:

Suppose `master/` navigates to the default site. When the friendly URL is modified for said site to, for example, `/guestfoo`, navigation will fail for `master/` and must be changed to `master/web/guest` to navigate correctly. Impersonating another user also results in the same error. A workaround to both of these problems is to change the Home URL to `/` in Configuration > Instance Settings > Instance Configuration > General.