### PR TITLE
LPS-106664 Fix erasure of instant messenger, SMS, and social network fields

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5069,10 +5069,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		screenName = getLogin(screenName);
 		emailAddress = StringUtil.toLowerCase(StringUtil.trim(emailAddress));
 		openId = StringUtil.trim(openId);
-		facebookSn = StringUtil.toLowerCase(StringUtil.trim(facebookSn));
-		jabberSn = StringUtil.toLowerCase(StringUtil.trim(jabberSn));
-		skypeSn = StringUtil.toLowerCase(StringUtil.trim(skypeSn));
-		twitterSn = StringUtil.toLowerCase(StringUtil.trim(twitterSn));
 
 		EmailAddressGenerator emailAddressGenerator =
 			EmailAddressGeneratorFactory.getInstance();
@@ -5213,11 +5209,35 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		contact.setSuffixId(suffixId);
 		contact.setMale(male);
 		contact.setBirthday(birthday);
-		contact.setSmsSn(smsSn);
-		contact.setFacebookSn(facebookSn);
-		contact.setJabberSn(jabberSn);
-		contact.setSkypeSn(skypeSn);
-		contact.setTwitterSn(twitterSn);
+
+		if (smsSn != null) {
+			contact.setSmsSn(smsSn);
+		}
+
+		if (facebookSn != null) {
+			facebookSn = StringUtil.toLowerCase(StringUtil.trim(facebookSn));
+
+			contact.setFacebookSn(facebookSn);
+		}
+
+		if (jabberSn != null) {
+			jabberSn = StringUtil.toLowerCase(StringUtil.trim(jabberSn));
+
+			contact.setJabberSn(jabberSn);
+		}
+
+		if (skypeSn != null) {
+			skypeSn = StringUtil.toLowerCase(StringUtil.trim(skypeSn));
+
+			contact.setSkypeSn(skypeSn);
+		}
+
+		if (twitterSn != null) {
+			twitterSn = StringUtil.toLowerCase(StringUtil.trim(twitterSn));
+
+			contact.setTwitterSn(twitterSn);
+		}
+
 		contact.setJobTitle(jobTitle);
 
 		contactPersistence.update(contact, serviceContext);


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-106664](https://issues.liferay.com/browse/LPS-106664)**

When editing a user, the Jabber, Skype, SMS, Facebook, and Twitter fields are erased when saving via the General tab.

## Analysis :nerd_face:

[LPS-76551](https://issues.liferay.com/browse/LPS-76551) extracted the logic to set the aforementioned fields into the `users_admin/update_user_contact_information_form` action, which is invoked when saving via the Contact tab. As part of this process, the original `users_admin/edit_user` action was changed so that the fields would be set to `null`. However, saving via the General tab still invokes the `users_admin/edit_user` action, which now erases the fields.

## Solution :tada:

We implement a null check for each of the fields; if the field is `null`, then we use the values currently stored in the user's contact information.