### PR TITLE
LPS-110278 Update draft layouts

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -3027,6 +3027,14 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		Layout layout = updateParentLayoutId(plid, parentPlid);
 
+		Layout draftLayout = fetchLayout(
+			classNameLocalService.getClassNameId(Layout.class),
+			layout.getPlid());
+
+		if (draftLayout != null) {
+			updateParentLayoutId(draftLayout.getPlid(), parentPlid);
+		}
+
 		return layoutLocalService.updatePriority(layout, priority);
 	}
 


### PR DESCRIPTION
<https://issues.liferay.com/browse/LPS-110278>

Hey @wanderlast,

When the parent of a content page layout is updated, the parent of the corresponding draft layout must also be updated. However, this was not the case. Thus, draft layouts would reference the wrong parent layouts (potentially deleted ones). The layout permission checker looks at the parent of each layout, including draft layouts, as seen in the following:

* <https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java#L268-L279>.

Because of this, the layout permission checker can potentially look for a deleted layout and throw a `NoSuchLayoutException`, which was causing the problem described in [LPP-36654](https://issues.liferay.com/browse/LPP-36654).

With regards,
Kevin