### PR TITLE
LPS-110134 Propagate image description when creating a new image from an edit of another image edit

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -214,6 +214,7 @@ const ItemSelectorPreview = ({
 		};
 
 		const editedItem = {
+			description: currentItem.description,
 			metadata: JSON.stringify(editedItemMetadata),
 			returntype: uploadItemReturnType,
 			title: itemData.title,


### PR DESCRIPTION
[LPS-110134](https://issues.liferay.com/browse/LPS-110134)

This handles an edge case from the solution introduced by [LPS-107966](https://issues.liferay.com/browse/LPS-107966), which propagates the image description when creating a new image via an image edit in Web Content.

![image](https://user-images.githubusercontent.com/56003471/76664712-81e90380-6542-11ea-9921-97098d3d3fa8.png)

After the first edited image is created, creating another image from this image edit results in the new image having a description of "undefined." To resolve this, we propagate the image description by adding an additional `description` field to the `editedItem` in `handleSaveEdit`.