### PR TITLE
LPS-110418 Prevent NullPointerException from being thrown

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -52,7 +52,7 @@ if (notificationUnread) {
 			<liferay-ui:message key="notification-no-longer-applies" />
 		</liferay-ui:search-container-column-text>
 	</c:when>
-	<c:when test="<%= userNotificationFeedEntry != null && !userNotificationFeedEntry.isApplicable() %>">
+	<c:when test="<%= (userNotificationFeedEntry != null) && !userNotificationFeedEntry.isApplicable() %>">
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -52,7 +52,7 @@ if (notificationUnread) {
 			<liferay-ui:message key="notification-no-longer-applies" />
 		</liferay-ui:search-container-column-text>
 	</c:when>
-	<c:when test="<%= !userNotificationFeedEntry.isApplicable() %>">
+	<c:when test="<%= userNotificationFeedEntry != null && !userNotificationFeedEntry.isApplicable() %>">
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>


### PR DESCRIPTION
<https://issues.liferay.com/browse/LPS-110418>

Hi @wanderlast,

The issue was that the notification portlet tried to invoke a method on the `userNotificationFeedEntry` variable when it was set to `null`.

* <https://github.com/kevhlee/liferay-portal/blob/4c6f47997f515e43e4ee78f52b5a64df6d9fdcec/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf#L55>

When a notification comes from a module that is uninstalled or deactivated, its corresponding `userNotificationFeedEntry` variable is set to `null`, which causes the problem described in [LPS-110418](https://issues.liferay.com/browse/LPS-110418).

With regards,
Kevin