### PR TITLE
LPS-110951 Remove color CSS class when the color is not set

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/heading/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/heading/index.js
@@ -1,0 +1,4 @@
+const heading = fragmentElement.querySelector(".component-heading");
+if (heading.classList.contains("text-")) {
+	heading.classList.remove("text-");
+}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/paragraph/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/paragraph/index.js
@@ -1,0 +1,4 @@
+const paragraph = fragmentElement.querySelector(".component-paragraph");
+if (paragraph.classList.contains("text-")) {
+	paragraph.classList.remove("text-");
+}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/separator/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/separator/index.js
@@ -1,0 +1,4 @@
+const separator = fragmentElement.querySelector(".m-0");
+if (separator.classList.contains("border-")) {
+	separator.classList.remove("border-");
+}


### PR DESCRIPTION
<https://issues.liferay.com/browse/LPS-110951>

Hey @wanderlast,

The issue was that any basic component that uses color palettes would display a color CSS class in its HTML when no color was set. The expected behavior is that the color CSS class should not appear in the HTML (see [PTR-1597](https://issues.liferay.com/browse/PTR-1597)). To resolve this issue, I update the `index.js` for each component and remove the color CSS class when there is a 'hanging' dash symbol (which would suggest that no color has been selected). The issue affects the Separator, Heading, and Paragraph basic components. 

With regards,
Kevin