### PR TITLE
LPS-111194 Send review email only for latest web content version

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7129,18 +7129,14 @@ public class JournalArticleLocalServiceImpl
 			_previousCheckDate);
 
 		for (JournalArticle article : articles) {
-			if (article.isInTrash()) {
-				continue;
-			}
-
 			long groupId = article.getGroupId();
 			String articleId = article.getArticleId();
 
-			if (!journalArticleLocalService.isLatestVersion(
+			if (article.isInTrash() ||
+				!journalArticleLocalService.isLatestVersion(
 					groupId, articleId, article.getVersion())) {
 
-				article = journalArticleLocalService.getLatestArticle(
-					groupId, articleId);
+				continue;
 			}
 
 			if (latestArticleIds.add(article.getPrimaryKey())) {


### PR DESCRIPTION
<https://issues.liferay.com/browse/LPS-111194>

Hi @wanderlast,

The issue was that a notification email to review the latest version of a journal article would be sent for each version. For example, if a previous version had a review date of 03/20/20 and the latest version had a review date of 03/21/20, the portal would send review notification emails for both dates. A review notification email should only be sent for the latest version of a journal article. To fix this issue, I modified and corrected `checkArticlesByReviewDate()` to only consider the latest versions of journal articles. 

With regards,
Kevin