### PR TITLE
LPS-111718 Prevent calendar booking's asset fields from being overwritten

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -19,8 +19,8 @@ import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetLink;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetLinkLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetLinkLocalService;
 import com.liferay.calendar.constants.CalendarPortletKeys;
 import com.liferay.calendar.exception.CalendarBookingDurationException;
 import com.liferay.calendar.exception.CalendarBookingRecurrenceException;
@@ -640,10 +640,10 @@ public class CalendarPortlet extends MVCPortlet {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CalendarBooking.class.getName(), actionRequest);
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			CalendarBooking.class.getName(), calendarBookingId);
 
-		List<AssetLink> assetLinks = AssetLinkLocalServiceUtil.getLinks(
+		List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
 			assetEntry.getEntryId());
 
 		long[] assetLinkEntryIds = ListUtil.toLongArray(
@@ -1812,6 +1812,12 @@ public class CalendarPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarPortlet.class);
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private AssetLinkLocalService _assetLinkLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.calendar.model.Calendar)"


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-111718

Hi @wanderlast,

When the user updates a calendar booking, a new booking is created with the update and the old one is deleted, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L1386-L1458). The issue is that, when updates are made using the "Save" button or when the RSVP value is changed, the assets of the old booking are not stored in the service context and therefore not passed to the new booking. The service context is used to update the asset fields of calendar bookings, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L267-L271).

To fix this issue, I made sure that the assets of the old booking are stored in the service context before the booking is updated. For finding the asset link entry IDs, I followed the logic found in [AssetLinksTag.java](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java#L206-L213). I do not use `AssetLink.ENTRY_ID2_ACCESSOR` as it can lead to strange results, such as having a calendar booking reference itself under the `Related Assets` section.

With regards,
Kevin