### PR TITLE
LPS-109824 Rename "Sites" column title to "Sites and Asset Libraries" in permissions summary

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_summary.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_summary.jsp
@@ -44,7 +44,7 @@
 		headerNames.add("permissions");
 
 		if (role.getType() == RoleConstants.TYPE_REGULAR) {
-			headerNames.add("sites");
+			headerNames.add("sites-and-asset-libraries");
 		}
 
 		headerNames.add(StringPool.BLANK);

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -4476,6 +4476,7 @@ sitemap=Sitemap
 sitemap-protocol=Sitemap Protocol
 siteminder=SiteMinder
 sites=Sites
+sites-and-asset-libraries=Sites and Asset Libraries
 sites-and-libraries=Sites and Libraries
 sites-home=Sites Home
 sites-joined=Sites I Have Joined


### PR DESCRIPTION
## Previous Pull Requests

https://github.com/wanderlast/liferay-portal/pull/46 > https://github.com/ChrisKian/liferay-portal/pull/190 > https://github.com/drewbrokke/liferay-portal/pull/992 > https://github.com/brianchandotcom/liferay-portal/pull/85985

## Overview

This is an update to [LPS-109824](https://issues.liferay.com/browse/LPS-109824) which changes the rename to be more specific as described [here](https://github.com/brianchandotcom/liferay-portal/pull/85985#issuecomment-596826659).