### PR TITLE
LPS-112111

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetRendererUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetRendererUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.asset.publisher.web.internal.util;
 
 import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
@@ -31,11 +32,19 @@ public class AssetRendererUtil {
 			AssetRenderer assetRenderer, HttpServletRequest httpServletRequest)
 		throws PortalException {
 
-		if (assetRenderer.getUserId() > 0) {
-			User assetRendererUser = UserLocalServiceUtil.getUser(
-				assetRenderer.getUserId());
+		long assetRendererUserId = assetRenderer.getUserId();
 
-			return assetRendererUser.getFullName();
+		if (assetRendererUserId > 0) {
+			User user = null;
+
+			try {
+				user = UserLocalServiceUtil.getUser(assetRendererUserId);
+			}
+			catch (NoSuchUserException noSuchUserException) {
+				return LanguageUtil.get(httpServletRequest, "deleted-user");
+			}
+
+			return user.getFullName();
 		}
 
 		return LanguageUtil.get(httpServletRequest, "anonymous");


### PR DESCRIPTION
[LPS-112111](https://issues.liferay.com/browse/LPS-112111)

Displaying content from a deleted user in an Asset Publisher results in the content not displaying correctly, as well as "No User exists with the primary key XXXXX" errors in the logs. To resolve this issue, we implement a check to determine if the userId is valid before using it to retrieve the user.


