### PR TITLE
LPS-116317 Fix back arrow and cancel buttons for an organization's edit page

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
@@ -18,9 +18,31 @@
 
 <%
 OrganizationScreenNavigationDisplayContext organizationScreenNavigationDisplayContext = (OrganizationScreenNavigationDisplayContext)request.getAttribute(UsersAdminWebKeys.ORGANIZATION_SCREEN_NAVIGATION_DISPLAY_CONTEXT);
+
+long organizationId = organizationScreenNavigationDisplayContext.getOrganizationId();
+
+String backURL = organizationScreenNavigationDisplayContext.getBackURL();
+
+if (Validator.isNull(backURL)) {
+	backURL = renderResponse.createRenderURL().toString();
+}
+
+String redirect = ParamUtil.getString(request, "redirect");
+
+if (Validator.isNull(redirect)) {
+	PortletURL redirectURL = renderResponse.createRenderURL();
+
+	redirectURL.setParameter("mvcRenderCommandName", "/users_admin/edit_organization");
+	redirectURL.setParameter("organizationId", String.valueOf(organizationId));
+	redirectURL.setParameter("backURL", backURL);
+
+	redirect = redirectURL.toString();
+}
 %>
 
 <aui:form action="<%= organizationScreenNavigationDisplayContext.getEditOrganizationActionURL() %>" cssClass="portlet-users-admin-edit-organization" method="post" name="fm">
+	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+
 	<clay:sheet>
 		<c:if test="<%= organizationScreenNavigationDisplayContext.isShowTitle() %>">
 			<clay:sheet-header>
@@ -36,7 +58,7 @@ OrganizationScreenNavigationDisplayContext organizationScreenNavigationDisplayCo
 			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
-				<aui:button href="<%= organizationScreenNavigationDisplayContext.getBackURL() %>" type="cancel" />
+				<aui:button href="<%= backURL %>" type="cancel" />
 			</clay:sheet-footer>
 		</c:if>
 	</clay:sheet>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization_action.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization_action.jsp
@@ -25,6 +25,8 @@ if ((searchContainer != null) && (searchContainer instanceof OrganizationSearch)
 	redirect = searchContainer.getIteratorURL().toString();
 }
 
+String backURL = ParamUtil.get(request, "backURL", redirect);
+
 ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
 Organization organization = null;
@@ -58,7 +60,7 @@ long organizationGroupId = organization.getGroupId();
 	<c:if test="<%= hasUpdatePermission %>">
 		<portlet:renderURL var="editOrganizationURL">
 			<portlet:param name="mvcRenderCommandName" value="/users_admin/edit_organization" />
-			<portlet:param name="redirect" value="<%= redirect %>" />
+			<portlet:param name="backURL" value="<%= backURL %>" />
 			<portlet:param name="organizationId" value="<%= String.valueOf(organizationId) %>" />
 		</portlet:renderURL>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116317

Hi @wanderlast,

The issue is that when the save button is pressed, the POST request is made without redirect URL parameter, which results in the back arrow and cancel buttons lacking back URLs and no longer functioning. To resolve this issue, I first pass the redirect URL as input to the edit page's form. After that, I make sure that default redirect and back URLs are created when the input redirect and back URLs are null/blank. I also modify the redirect URL so that the portal would redirect the user back to the organization's edit page rather than the "view organizations" page.

With regards,
Kevin