### PR TITLE
LPS-117378 Make required categories for web content structures optional when editing default values

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.asset.validator;
+
+import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Kevin Lee
+ */
+@Component(
+	property = "model.class.name=com.liferay.journal.model.JournalArticle",
+	service = AssetEntryValidatorExclusionRule.class
+)
+public class JournalAssetEntryValidatorExclusionRule
+	implements AssetEntryValidatorExclusionRule {
+
+	@Override
+	public boolean isValidationExcluded(
+		long groupId, String className, long classPK, long classTypePK,
+		long[] categoryIds, String[] tagNames) {
+
+		return false;
+	}
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
@@ -43,12 +43,17 @@ public class JournalAssetEntryValidatorExclusionRule
 			_journalArticleResourceLocalService.fetchJournalArticleResource(
 				classPK);
 
+		if (journalArticleResource == null) {
+			return false;
+		}
+
 		JournalArticle journalArticle =
 			_journalArticleLocalService.fetchArticle(
 				groupId, journalArticleResource.getArticleId());
 
-		if (journalArticle.getClassNameId() >
-				JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
+		if ((journalArticle != null) &&
+			(journalArticle.getClassNameId() >
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT)) {
 
 			return true;
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/validator/JournalAssetEntryValidatorExclusionRule.java
@@ -15,8 +15,14 @@
 package com.liferay.journal.internal.asset.validator;
 
 import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalArticleResource;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.service.JournalArticleResourceLocalService;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Kevin Lee
@@ -33,7 +39,28 @@ public class JournalAssetEntryValidatorExclusionRule
 		long groupId, String className, long classPK, long classTypePK,
 		long[] categoryIds, String[] tagNames) {
 
+		JournalArticleResource journalArticleResource =
+			_journalArticleResourceLocalService.fetchJournalArticleResource(
+				classPK);
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchArticle(
+				groupId, journalArticleResource.getArticleId());
+
+		if (journalArticle.getClassNameId() >
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
+
+			return true;
+		}
+
 		return false;
 	}
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference
+	private JournalArticleResourceLocalService
+		_journalArticleResourceLocalService;
 
 }


### PR DESCRIPTION
Relevant Tickets
- [LPS-117378](<https://issues.liferay.com/browse/LPS-117378>)
- [PTR-1829](<https://issues.liferay.com/browse/PTR-1829>)

Currently, default values for a web content structure cannot be edited when it has required categories. However, filling any category, required or not, should be optional when editing default values. The requirement should only apply when creating a web content article from the structure.

The issue is that asset entry validations (such as filling out mandatory fields/categories) are performed on a web content structure regardless of whether the user is editing it ("Edit") or editing its default values ("Edit Default Values"). Thus, an exclusion rule for journal articles needs to be added so that journal articles representing structure default values are excluded from asset entry validation. The solution is based on discussion in [PTR-1829](<https://issues.liferay.com/browse/PTR-1829>).