### PR TITLE
LPS-117593 Append namespace to layout action CSS class names

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -190,7 +190,7 @@ const DatePicker = ({
 					}
 
 					if (moment(value).isValid()) {
-						onChange(moment(value).format(dateMask));
+						onChange(moment(value).format(dateMask.toUpperCase()));
 					}
 				}}
 				ref={inputRef}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -163,4 +163,35 @@ describe('DatePicker', () => {
 
 		expect(handleFieldEdited).toHaveBeenCalled();
 	});
+
+	it('call the onChange callback with a valid date', async () => {
+		const onChange = jest.fn();
+
+		const {container, getAllByDisplayValue, getByLabelText} = render(
+			<DatePickerWithProvider
+				{...defaultDatePickerConfig}
+				onChange={onChange}
+			/>
+		);
+
+		userEvent.click(
+			container.querySelector('.date-picker-dropdown-toggle')
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		userEvent.click(getByLabelText('Select current date'));
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const date = moment().format('MM/DD/YYYY');
+
+		await wait(() => expect(getAllByDisplayValue(date)).toBeTruthy());
+
+		expect(onChange).toHaveBeenCalledWith({}, date);
+	});
 });

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -61,7 +61,7 @@ Layout curLayout = (Layout)row.getObject();
 
 	<c:if test="<%= layoutsAdminDisplayContext.isShowCopyLayoutAction(curLayout) %>">
 		<liferay-ui:icon
-			cssClass="copy-layout-action-option"
+			cssClass='<%= liferayPortletResponse.getNamespace() + "copy-layout-action-option" %>'
 			message="copy-page"
 			url="javascript:;"
 		/>
@@ -105,7 +105,7 @@ Layout curLayout = (Layout)row.getObject();
 
 	<c:if test="<%= layoutsAdminDisplayContext.isShowViewCollectionItemsAction(curLayout) %>">
 		<liferay-ui:icon
-			cssClass="view-collection-items-action-option"
+			cssClass='<%= liferayPortletResponse.getNamespace() + "view-collection-items-action-option" %>'
 			message="view-collection-items"
 			url="javascript:;"
 		/>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
@@ -14,8 +14,10 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -95,70 +97,99 @@ const ExperienceItem = ({
 		>
 			<ClayList.ItemField expand>
 				<ClayButton displayType="unstyled" onClick={handleSelect}>
-					<strong className="text-truncate">
-						{experience.name}
+					<ClayLayout.ContentRow verticalAlign="center">
+						<ClayLayout.ContentCol
+							style={{flexShrink: 1, minWidth: 0}}
+						>
+							<ClayLayout.ContentSection>
+								<span className="text-truncate-inline">
+									<ClayTooltipProvider>
+										<span
+											className="font-weight-semi-bold text-truncate"
+											data-tooltip-align="top"
+											title={experience.name}
+										>
+											{experience.name}
+										</span>
+									</ClayTooltipProvider>
 
-						{experience.hasLockedSegmentsExperiment && (
-							<>
-								<ClayIcon
-									className="ml-2 text-secondary"
-									onMouseEnter={() => setShowtoolTip(true)}
-									onMouseLeave={() => setShowtoolTip(false)}
-									ref={iconRef}
-									symbol="lock"
-								/>
+									{experience.hasLockedSegmentsExperiment && (
+										<span>
+											<ClayIcon
+												className="text-secondary"
+												onMouseEnter={() =>
+													setShowtoolTip(true)
+												}
+												onMouseLeave={() =>
+													setShowtoolTip(false)
+												}
+												ref={iconRef}
+												symbol="lock"
+											/>
 
-								{showtoolTip && (
-									<Popover
-										anchor={iconRef.current}
-										header={Liferay.Language.get(
-											'experience-locked'
-										)}
-									>
-										{Liferay.Language.get(
-											'edit-is-not-allowed-for-this-experience'
-										)}
-									</Popover>
+											{showtoolTip && (
+												<Popover
+													anchor={iconRef.current}
+													header={Liferay.Language.get(
+														'experience-locked'
+													)}
+												>
+													{Liferay.Language.get(
+														'edit-is-not-allowed-for-this-experience'
+													)}
+												</Popover>
+											)}
+										</span>
+									)}
+								</span>
+
+								<span className="text-truncate">
+									<span className="mr-1 text-secondary">
+										{Liferay.Language.get('audience')}
+									</span>
+									{experience.segmentsEntryName}
+								</span>
+
+								{experience.segmentsExperimentStatus && (
+									<div>
+										<span className="font-weight-normal mr-1 text-secondary">
+											{Liferay.Language.get('ab-test')}
+										</span>
+
+										<ExperimentLabel
+											label={
+												experience
+													.segmentsExperimentStatus
+													.label
+											}
+											value={
+												experience
+													.segmentsExperimentStatus
+													.value
+											}
+										/>
+									</div>
 								)}
-							</>
-						)}
-					</strong>
-
-					<span className="text-truncate">
-						<span className="mr-1 text-secondary">
-							{Liferay.Language.get('audience')}
-						</span>
-						{experience.segmentsEntryName}
-					</span>
-
-					{experience.segmentsExperimentStatus && (
-						<div>
-							<span className="font-weight-normal mr-1 text-secondary">
-								{Liferay.Language.get('ab-test')}
-							</span>
-
-							<ExperimentLabel
-								label={
-									experience.segmentsExperimentStatus.label
-								}
-								value={
-									experience.segmentsExperimentStatus.value
-								}
-							/>
-						</div>
-					)}
+							</ClayLayout.ContentSection>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
 				</ClayButton>
 			</ClayList.ItemField>
 
 			<ClayList.ItemField className="align-self-center">
 				{editable && (
-					<div className="px-2">
+					<div className="pl-2">
 						<ClayButtonWithIcon
-							className="component-action mx-2 text-secondary"
+							aria-label={Liferay.Language.get(
+								'prioritize-experience'
+							)}
+							borderless
+							className="component-action mx-1"
 							disabled={lockedIncreasePriority}
 							displayType="unstyled"
+							monospaced
 							onClick={handlePriorityIncrease}
-							small
+							outline
 							symbol="angle-up"
 							title={Liferay.Language.get(
 								'prioritize-experience'
@@ -167,11 +198,16 @@ const ExperienceItem = ({
 						/>
 
 						<ClayButtonWithIcon
-							className="component-action mx-2 text-secondary"
+							aria-label={Liferay.Language.get(
+								'deprioritize-experience'
+							)}
+							borderless
+							className="component-action mx-1"
 							disabled={lockedDecreasePriority}
 							displayType="unstyled"
+							monospaced
 							onClick={handlePriorityDecrease}
-							small
+							outline
 							symbol="angle-down"
 							title={Liferay.Language.get(
 								'deprioritize-experience'
@@ -180,20 +216,28 @@ const ExperienceItem = ({
 						/>
 
 						<ClayButtonWithIcon
-							className="component-action mx-2 text-secondary"
+							aria-label={Liferay.Language.get('edit-experience')}
+							borderless
+							className="component-action mx-1"
 							displayType="unstyled"
+							monospaced
 							onClick={handleExperienceEdit}
-							small
+							outline
 							symbol="pencil"
 							title={Liferay.Language.get('edit-experience')}
 							type="button"
 						/>
 
 						<ClayButtonWithIcon
-							className="component-action mx-2 text-secondary"
+							aria-label={Liferay.Language.get(
+								'delete-experience'
+							)}
+							borderless
+							className="component-action mx-1"
 							displayType="unstyled"
+							monospaced
 							onClick={handleExperienceDelete}
-							small
+							outline
 							symbol="times-circle"
 							title={Liferay.Language.get('delete-experience')}
 							type="button"
@@ -203,12 +247,18 @@ const ExperienceItem = ({
 
 				{experience.hasLockedSegmentsExperiment &&
 					experience.segmentsExperimentURL && (
-						<div className="px-2">
+						<div className="pl-2">
 							<ClayLink
-								className="component-action mx-2"
-								displayType="secondary"
+								aria-label={Liferay.Language.get(
+									'go-to-test-details'
+								)}
+								borderless
+								className="component-action mx-1"
+								displayType="unstyled"
 								href={experience.segmentsExperimentURL}
+								monospaced
 								onClick={handleExperimentNavigation}
+								outline
 								title={Liferay.Language.get(
 									'go-to-test-details'
 								)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
@@ -39,8 +39,6 @@ const ExperienceItem = ({
 	onPriorityIncrease,
 	onSelect,
 }) => {
-	const iconRef = React.useRef();
-	const [showtoolTip, setShowtoolTip] = React.useState(false);
 	const handleSelect = () => onSelect(experience.segmentsExperienceId);
 	const handlePriorityIncrease = () =>
 		onPriorityIncrease(
@@ -114,32 +112,7 @@ const ExperienceItem = ({
 									</ClayTooltipProvider>
 
 									{experience.hasLockedSegmentsExperiment && (
-										<span>
-											<ClayIcon
-												className="text-secondary"
-												onMouseEnter={() =>
-													setShowtoolTip(true)
-												}
-												onMouseLeave={() =>
-													setShowtoolTip(false)
-												}
-												ref={iconRef}
-												symbol="lock"
-											/>
-
-											{showtoolTip && (
-												<Popover
-													anchor={iconRef.current}
-													header={Liferay.Language.get(
-														'experience-locked'
-													)}
-												>
-													{Liferay.Language.get(
-														'edit-is-not-allowed-for-this-experience'
-													)}
-												</Popover>
-											)}
-										</span>
+										<ExperienceLockIcon />
 									)}
 								</span>
 
@@ -175,100 +148,147 @@ const ExperienceItem = ({
 					</ClayLayout.ContentRow>
 				</ClayButton>
 			</ClayList.ItemField>
-
 			<ClayList.ItemField className="align-self-center">
-				{editable && (
-					<div className="pl-2">
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get(
-								'prioritize-experience'
-							)}
-							borderless
-							className="component-action mx-1"
-							disabled={lockedIncreasePriority}
-							displayType="unstyled"
-							monospaced
-							onClick={handlePriorityIncrease}
-							outline
-							symbol="angle-up"
-							title={Liferay.Language.get(
-								'prioritize-experience'
-							)}
-							type="button"
-						/>
-
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get(
-								'deprioritize-experience'
-							)}
-							borderless
-							className="component-action mx-1"
-							disabled={lockedDecreasePriority}
-							displayType="unstyled"
-							monospaced
-							onClick={handlePriorityDecrease}
-							outline
-							symbol="angle-down"
-							title={Liferay.Language.get(
-								'deprioritize-experience'
-							)}
-							type="button"
-						/>
-
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get('edit-experience')}
-							borderless
-							className="component-action mx-1"
-							displayType="unstyled"
-							monospaced
-							onClick={handleExperienceEdit}
-							outline
-							symbol="pencil"
-							title={Liferay.Language.get('edit-experience')}
-							type="button"
-						/>
-
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get(
-								'delete-experience'
-							)}
-							borderless
-							className="component-action mx-1"
-							displayType="unstyled"
-							monospaced
-							onClick={handleExperienceDelete}
-							outline
-							symbol="times-circle"
-							title={Liferay.Language.get('delete-experience')}
-							type="button"
-						/>
-					</div>
-				)}
-
-				{experience.hasLockedSegmentsExperiment &&
-					experience.segmentsExperimentURL && (
-						<div className="pl-2">
-							<ClayLink
-								aria-label={Liferay.Language.get(
-									'go-to-test-details'
-								)}
-								borderless
-								className="component-action mx-1"
-								displayType="unstyled"
-								href={experience.segmentsExperimentURL}
-								monospaced
-								onClick={handleExperimentNavigation}
-								outline
-								title={Liferay.Language.get(
-									'go-to-test-details'
-								)}
-							>
-								<ClayIcon symbol="test" />
-							</ClayLink>
-						</div>
-					)}
+				<ExperienceActions
+					editable={editable}
+					experience={experience}
+					handleExperienceDelete={handleExperienceDelete}
+					handleExperienceEdit={handleExperienceEdit}
+					handleExperimentNavigation={handleExperimentNavigation}
+					handlePriorityDecrease={handlePriorityDecrease}
+					handlePriorityIncrease={handlePriorityIncrease}
+					lockedDecreasePriority={lockedDecreasePriority}
+					lockedIncreasePriority={lockedIncreasePriority}
+				/>
 			</ClayList.ItemField>
 		</ClayList.Item>
+	);
+};
+
+const ExperienceActions = ({
+	editable,
+	experience,
+	handleExperienceDelete,
+	handleExperienceEdit,
+	handleExperimentNavigation,
+	handlePriorityDecrease,
+	handlePriorityIncrease,
+	lockedDecreasePriority,
+	lockedIncreasePriority,
+}) => {
+	return (
+		<>
+			{editable && (
+				<div className="pl-2">
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get(
+							'prioritize-experience'
+						)}
+						borderless
+						className="component-action mx-1"
+						disabled={lockedIncreasePriority}
+						displayType="unstyled"
+						monospaced
+						onClick={handlePriorityIncrease}
+						outline
+						symbol="angle-up"
+						title={Liferay.Language.get('prioritize-experience')}
+						type="button"
+					/>
+
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get(
+							'deprioritize-experience'
+						)}
+						borderless
+						className="component-action mx-1"
+						disabled={lockedDecreasePriority}
+						displayType="unstyled"
+						monospaced
+						onClick={handlePriorityDecrease}
+						outline
+						symbol="angle-down"
+						title={Liferay.Language.get('deprioritize-experience')}
+						type="button"
+					/>
+
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('edit-experience')}
+						borderless
+						className="component-action mx-1"
+						displayType="unstyled"
+						monospaced
+						onClick={handleExperienceEdit}
+						outline
+						symbol="pencil"
+						title={Liferay.Language.get('edit-experience')}
+						type="button"
+					/>
+
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('delete-experience')}
+						borderless
+						className="component-action mx-1"
+						displayType="unstyled"
+						monospaced
+						onClick={handleExperienceDelete}
+						outline
+						symbol="times-circle"
+						title={Liferay.Language.get('delete-experience')}
+						type="button"
+					/>
+				</div>
+			)}
+
+			{experience.hasLockedSegmentsExperiment &&
+				experience.segmentsExperimentURL && (
+					<div className="pl-2">
+						<ClayLink
+							aria-label={Liferay.Language.get(
+								'go-to-test-details'
+							)}
+							borderless
+							className="component-action mx-1"
+							displayType="unstyled"
+							href={experience.segmentsExperimentURL}
+							monospaced
+							onClick={handleExperimentNavigation}
+							outline
+							title={Liferay.Language.get('go-to-test-details')}
+						>
+							<ClayIcon symbol="test" />
+						</ClayLink>
+					</div>
+				)}
+		</>
+	);
+};
+
+const ExperienceLockIcon = () => {
+	const iconRef = React.useRef();
+	const [showtoolTip, setShowtoolTip] = React.useState(false);
+
+	return (
+		<span>
+			<ClayIcon
+				className="text-secondary"
+				onMouseEnter={() => setShowtoolTip(true)}
+				onMouseLeave={() => setShowtoolTip(false)}
+				ref={iconRef}
+				symbol="lock"
+			/>
+
+			{showtoolTip && (
+				<Popover
+					anchor={iconRef.current}
+					header={Liferay.Language.get('experience-locked')}
+				>
+					{Liferay.Language.get(
+						'edit-is-not-allowed-for-this-experience'
+					)}
+				</Popover>
+			)}
+		</span>
 	);
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -280,7 +280,7 @@ const ExperienceSelector = ({
 	return (
 		<>
 			<ClayButton
-				className="align-items-end d-inline-flex form-control-select justify-content-between mr-2 text-left text-truncate"
+				className="form-control-select pr-4 text-left text-truncate"
 				displayType="secondary"
 				id={selectId}
 				onBlur={handleDropdownButtonBlur}
@@ -289,11 +289,18 @@ const ExperienceSelector = ({
 				small
 				type="button"
 			>
-				<span className="text-truncate">{selectedExperience.name}</span>
-
-				{selectedExperience.hasLockedSegmentsExperiment && (
-					<ClayIcon className="mr-3" symbol="lock" />
-				)}
+				<ClayLayout.ContentRow verticalAlign="center">
+					<ClayLayout.ContentCol expand>
+						<span className="text-truncate">
+							{selectedExperience.name}
+						</span>
+					</ClayLayout.ContentCol>
+					<ClayLayout.ContentCol>
+						{selectedExperience.hasLockedSegmentsExperiment && (
+							<ClayIcon symbol="lock" />
+						)}
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</ClayButton>
 
 			{open &&

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -197,6 +197,7 @@ describe('ExperienceToolbarSection', () => {
 		});
 
 		const {
+			getAllByRole,
 			getByLabelText,
 			getByRole,
 			getByText,
@@ -212,9 +213,11 @@ describe('ExperienceToolbarSection', () => {
 
 		await waitForElement(() => getByRole('list'));
 
-		const experience = getByText('Experience #3');
+		expect(getByText('Experience #3')).toBeInTheDocument();
 
-		const lockIcon = within(experience).getByRole('presentation');
+		const icons = getAllByRole('presentation');
+
+		const lockIcon = icons[1];
 
 		// Hackily work around:
 		//

--- a/modules/apps/ratings/ratings-test/src/testFunctional/Ratings.testcase
+++ b/modules/apps/ratings/ratings-test/src/testFunctional/Ratings.testcase
@@ -513,7 +513,9 @@ definition {
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
 
-		Ratings.rateThumb(ratingResult = "Rate this as bad");
+		Ratings.rateThumb(
+			blogRating = "true",
+			ratingResult = "Rate this as bad");
 
 		Ratings.viewRateThumb(
 			ratingResult = "Rate this as good",
@@ -523,7 +525,9 @@ definition {
 			ratingResult = "You have rated this as bad",
 			voteCount = "1");
 
-		Ratings.rateThumb(ratingResult = "Rate this as good");
+		Ratings.rateThumb(
+			blogRating = "true",
+			ratingResult = "Rate this as good");
 
 		Ratings.viewRateThumb(
 			ratingResult = "You have rated this as good",
@@ -545,7 +549,9 @@ definition {
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
 
-		Ratings.rateThumb(ratingResult = "Rate this as good");
+		Ratings.rateThumb(
+			blogRating = "true",
+			ratingResult = "Rate this as good");
 
 		Ratings.viewRateThumb(
 			ratingResult = "You have rated this as good",
@@ -555,7 +561,9 @@ definition {
 			ratingResult = "Rate this as bad",
 			voteCount = "0");
 
-		Ratings.rateThumb(ratingResult = "Rate this as bad");
+		Ratings.rateThumb(
+			blogRating = "true",
+			ratingResult = "Rate this as bad");
 
 		Ratings.viewRateThumb(
 			ratingResult = "Rate this as good",

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/css/EditApp.scss
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/css/EditApp.scss
@@ -226,10 +226,6 @@ $navbarHeight: 120px;
 	border: 1px solid #cdced9;
 	border-radius: 6px;
 	box-sizing: border-box;
-	margin-bottom: 1rem;
+	margin-top: 1rem;
 	padding: 1rem 1rem 0;
-
-	&:first-of-type {
-		margin-top: 1rem;
-	}
 }

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/EditApp.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/EditApp.es.js
@@ -77,7 +77,7 @@ export default ({
 	};
 
 	useEffect(() => {
-		if (!appId && app.dataDefinitionId) {
+		if (app.dataDefinitionId) {
 			dispatchConfig({
 				listItems: {fetching: true},
 				type: UPDATE_LIST_ITEMS,
@@ -104,7 +104,7 @@ export default ({
 					});
 				});
 		}
-	}, [appId, app.dataDefinitionId]);
+	}, [app.dataDefinitionId]);
 
 	useEffect(() => {
 		const promises = [getAssigneeRoles(), getDataObjects()];

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/configReducer.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/configReducer.es.js
@@ -218,9 +218,17 @@ export default (state, action) => {
 			};
 		}
 		case UPDATE_DATA_OBJECT: {
+			state.steps.forEach((step) => {
+				if (step.appWorkflowDataLayoutLinks) {
+					step.appWorkflowDataLayoutLinks = [];
+				}
+			});
+
 			return {
 				...state,
 				dataObject: action.dataObject,
+				formView: {},
+				tableView: {},
 			};
 		}
 		case UPDATE_FORM_VIEW: {

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/DataAndViewsTab.es.js
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-web/src/main/resources/META-INF/resources/js/pages/apps/edit/sidebar/DataAndViewsTab.es.js
@@ -100,7 +100,6 @@ export default function DataAndViewsTab() {
 		},
 		dispatch,
 		dispatchConfig,
-		state: {app},
 	} = useContext(EditAppContext);
 
 	const {appWorkflowDataLayoutLinks: stepFormViews = []} = currentStep;
@@ -126,16 +125,18 @@ export default function DataAndViewsTab() {
 		});
 	};
 
-	const updateDataObject = (dataObject) => {
-		dispatchConfig({
-			dataObject,
-			type: UPDATE_DATA_OBJECT,
-		});
+	const updateDataObject = (newDataObject) => {
+		if (newDataObject.id !== dataObject.id) {
+			dispatchConfig({
+				dataObject: newDataObject,
+				type: UPDATE_DATA_OBJECT,
+			});
 
-		dispatch({
-			...dataObject,
-			type: UPDATE_DATA_DEFINITION_ID,
-		});
+			dispatch({
+				...newDataObject,
+				type: UPDATE_DATA_DEFINITION_ID,
+			});
+		}
 	};
 
 	const updateFormView = (formView) => {
@@ -251,7 +252,7 @@ export default function DataAndViewsTab() {
 					)}
 
 					<ClayButton
-						className="w-100"
+						className="mt-3 w-100"
 						displayType="secondary"
 						onClick={addStepFormView}
 					>
@@ -280,7 +281,6 @@ export default function DataAndViewsTab() {
 						</ClayTooltipProvider>
 
 						<SelectObjects
-							defaultValue={app.dataDefinitionId}
 							label={Liferay.Language.get('select-object')}
 							onSelect={updateDataObject}
 							selectedValue={dataObject}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/MultiFactorAuthentication.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MultiFactorAuthentication.macro
@@ -128,9 +128,7 @@ definition {
 	}
 
 	macro sendOTPEmailPG {
-		AssertTextEquals.assertPartialText(
-			locator1 = "MultiFactorAuthentication#EMAIL_OTP_VERIFY_INFO_MESSAGE",
-			value1 = "Press the button bellow to obtain your one-time password. It will be sent to");
+		AssertElementPresent(locator1 = "MultiFactorAuthentication#EMAIL_OTP_VERIFY_INFO_MESSAGE");
 
 		AssertClick(
 			locator1 = "MultiFactorAuthentication#EMAIL_OTP_VERIFY_SEND_EMAIL_BUTTON",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Ratings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Ratings.macro
@@ -95,6 +95,14 @@ definition {
 				locator1 = "Ratings#COMMENT_RATING_THUMB");
 		}
 
+		else if (isSet(blogRating)) {
+			Pause(locator1 = "2000");
+
+			Click.javaScriptClick(
+				key_ratingResult = "${ratingResult}",
+				locator1 = "Ratings#THUMB");
+		}
+
 		else if (isSet(commentRating)) {
 			Click.clickNoMouseOver(
 				key_ratingResult = "${ratingResult}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/support/patchingtool/PatchingTool.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/support/patchingtool/PatchingTool.testcase
@@ -7,6 +7,7 @@ definition {
 	property testray.main.component.name = "Patching Tool";
 	var testBuildFixPackZipURL = PropsUtil.get("test.build.fix.pack.zip.url");
 	var testBuildFixPackZipURLPrevious = PropsUtil.get("test.build.fix.pack.zip.url.previous");
+	var testBuildFixPackZipURLLatestHeavy = PropsUtil.get("test.build.fix.pack.zip.url.latest.heavy");
 
 	setUp {
 		SignIn.signInTestSetup();
@@ -50,6 +51,72 @@ definition {
 
 		for (var outputContent : list "Declarative Service Soft Circular Dependency Checker check result: No issues were found,Declarative Service Unsatisfied Component Checker check result: No issues were found,Spring Extender Unavailable Component Checker check result: No issues were found") {
 			GogoShell.viewOutput(outputContent = "${outputContent}");
+		}
+	}
+
+	@description = "Ensures that a fix pack can be reverted to the latest heavy fix pack."
+	@priority = "5"
+	test RevertToLatestHeavyFixPack {
+		property skip.install-patch = "true";
+		property test.name.skip.portal.instance = "PatchingTool#RevertToLatestHeavyFixPack";
+
+		if ("${testBuildFixPackZipURLPrevious}" == "${testBuildFixPackZipURLLatestHeavy}") {
+			echo("Skip test since the heavey fixpack equal to previous fixpack");
+		}
+		else {
+			SignOut.signOut();
+
+			Portlet.shutdownServer();
+
+			PatchingTool.installPatch(patchFileZipURL = "${testBuildFixPackZipURL}");
+
+			Portlet.startServer(
+				deleteLiferayHome = "true",
+				keepCachedAppServerData = "true");
+
+			SignIn.signIn();
+
+			JSONBlog.addEntry(
+				entryContent = "Blogs Entry Content",
+				entryTitle = "Blogs Entry Title");
+
+			JSONWebcontent.addWebContent(
+				content = "WC WebContent Content",
+				groupName = "Guest",
+				title = "WC WebContent Title");
+
+			JSONDocument.addFile(
+				dmDocumentDescription = "DM Document Description",
+				dmDocumentTitle = "DM Document Title",
+				groupName = "Guest");
+
+			Portlet.shutdownServer();
+
+			PatchingTool.uninstallPatches();
+
+			PatchingTool.installPatch(patchFileZipURL = "${testBuildFixPackZipURLLatestHeavy}");
+
+			Portlet.startServer(
+				deleteLiferayHome = "true",
+				keepCachedAppServerData = "true");
+
+			SignIn.signIn();
+
+			BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
+
+			LexiconEntry.changeDisplayStyle(displayStyle = "table");
+
+			BlogsEntry.viewEntryTable(entryTitle = "Blogs Entry Title");
+
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
+
+			WebContent.viewTitle(webContentTitle = "WC WebContent Title");
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+			DMDocument.checkoutCP(dmDocumentTitle = "DM Document Title");
 		}
 	}
 


### PR DESCRIPTION
Relevant Tickets:
- [LPS-117593](https://issues.liferay.com/browse/LPS-117593)

The issue occurs simply because the "copy layout" action requires the namespace for its icon's `cssClass`, as seen [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp#L119). I also appended the namespace to the "view collection items" action as its icon also requires it.