### PR TITLE
LPS-121467 Different organization types shouldn't be an option you can add in a Organization

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewTreeManagementToolbarDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewTreeManagementToolbarDisplayContext.java
@@ -214,7 +214,8 @@ public class ViewTreeManagementToolbarDisplayContext {
 
 				if (hasAddOrganizationPermission()) {
 					for (String organizationType :
-							OrganizationLocalServiceUtil.getTypes()) {
+							OrganizationLocalServiceUtil.getChildrenTypes(
+								_organization.getType())) {
 
 						PortletURL addOrganizationTypeURL =
 							_renderResponse.createRenderURL();


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-121467>

**Notes:**
The issue was simply the use of `OrganizationLocalServiceUtil.getTypes()`, which lists all available organization types. We need to only consider the available **children** types.

Let me know if you have any questions. Thanks!