### PR TITLE
LPS-122234 Site name in Control Panel is not being HTML escaped correctly

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -29,7 +29,7 @@ if (group != null) {
 
 	portletDisplay.setURLBack(backURL.toString());
 
-	renderResponse.setTitle(HtmlUtil.escape(group.getDescriptiveName(locale)));
+	renderResponse.setTitle(group.getDescriptiveName(locale));
 }
 %>
 


### PR DESCRIPTION
**Ticket:**
https://issues.liferay.com/browse/LPS-122234

**Description:**
The issue is simply that the site name is being HTML escaped twice. I removed the usage of `HtmlUtil.escape()` when storing the site name in the `renderResponse` as it seems the site name will be escaped elsewhere.

Let me know if you have any questions.