### PR TITLE
LPS-122254 Can select the current Web Content in Related Assets

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -67,6 +67,9 @@
 
 				cssClass = "selector-button";
 			}
+			else {
+				row.setSkip(true);
+			}
 			%>
 
 			<c:choose>

--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -94,7 +94,7 @@
 
 						<h5>
 							<c:choose>
-								<c:when test="<%= (assetEntry.getEntryId() != assetBrowserDisplayContext.getRefererAssetEntryId()) && !assetBrowserDisplayContext.isMultipleSelection() %>">
+								<c:when test="<%= !assetBrowserDisplayContext.isMultipleSelection() %>">
 									<aui:a cssClass="<%= cssClass %>" data="<%= data %>" href="javascript:;">
 										<%= HtmlUtil.escape(assetRenderer.getTitle(locale)) %>
 									</aui:a>
@@ -149,7 +149,7 @@
 						name="title"
 					>
 						<c:choose>
-							<c:when test="<%= (assetEntry.getEntryId() != assetBrowserDisplayContext.getRefererAssetEntryId()) && !assetBrowserDisplayContext.isMultipleSelection() %>">
+							<c:when test="<%= !assetBrowserDisplayContext.isMultipleSelection() %>">
 								<aui:a cssClass="<%= cssClass %>" data="<%= data %>" href="javascript:;">
 									<%= HtmlUtil.escape(assetRenderer.getTitle(locale)) %>
 								</aui:a>

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
@@ -340,9 +340,16 @@ public class InputAssetLinksDisplayContext {
 
 		ItemSelector itemSelector = ItemSelectorUtil.getItemSelector();
 
-		return itemSelector.getItemSelectorURL(
+		PortletURL portletURL = itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(_portletRequest),
 			getEventName(), assetEntryItemSelectorCriterion);
+
+		if (_assetEntryId > 0) {
+			portletURL.setParameter(
+				"refererAssetEntryId", String.valueOf(_assetEntryId));
+		}
+
+		return portletURL;
 	}
 
 	private List<Map<String, Object>> _getSelectorEntries(


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-122254>

**Notes:**
When using the "Related Assets" portlet, the current web content article is shown and selectable. There are two reasons for this behavior:

1. The `refererAssetEntryId`, which is used to identify the current or *referring* asset entry, is missing from `AssetBrowserDisplayContext.java` and defaults to `0`. The `refererAssetEntryId` is needed to prevent the current asset entry from being selected. This particular behavior is a regression caused by commit 7ad3d470258b180e from [LPS-119094](https://issues.liferay.com/browse/LPS-119094).
2. The search container for the "Related Assets" portlet does not exclude the referring asset entry from its results.

Thus, the solution is the following:

1. Make sure that the `refererAssetEntryId` is stored in the portlet URL so that we can check against the correct referring asset entry.
2. Remove the referring asset entry from the search results to avoid rendering it.

Let me know if you have any questions. Thank you!