### PR TITLE
LPS-122681, LPS-122683

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -581,7 +581,7 @@ AUI.add(
 					};
 
 					var webContentSelectorURL = Liferay.Util.PortletURL.createRenderURL(
-						themeDisplay.getURLControlPanel(),
+						themeDisplay.getLayoutRelativeControlPanelURL(),
 						webContentSelectorParameters
 					);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -573,7 +573,7 @@ AUI.add(
 						criteria:
 							'com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion',
 						itemSelectedEventName:
-							portletNamespace + 'selectContent',
+							portletNamespace + 'selectDocumentLibrary',
 						p_auth: Liferay.authToken,
 						p_p_id: Liferay.PortletKeys.ITEM_SELECTOR,
 						p_p_mode: 'view',


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-122681>
<https://issues.liferay.com/browse/LPS-122683>

**Notes:**
For [LPS-122681](https://issues.liferay.com/browse/LPS-122681), the wrong scope is used when selecting a predefined value for a web content field due to the use of `themeDisplay.getURLControlPanel()`. We need to use `themeDisplay.getLayoutRelativeControlPanelURL()`, as seen throughout `custom_fields.js`:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js#L365>

For [LPS-122683](https://issues.liferay.com/browse/LPS-122683), the predefined value cannot be set for the web content structure because`itemSelectedEventName` is incorrect; the event handler is expecting `selectDocumentLibrary` rather than `selectContent`, as seen here:

* <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js#L626>

Let me know if you have any questions.
