### PR TITLE
LPS-122910 NPE when reviewing a page change with conflict

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -69,6 +69,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -587,6 +588,21 @@ public class ViewChangesDisplayContext {
 		return rootClassNameIds;
 	}
 
+	private <T extends BaseModel<T>> String _getTitle(
+		long ctCollectionId, CTSQLModeThreadLocal.CTSQLMode ctSQLMode,
+		Locale locale, T model, long modelClassNameId, long modelClassPK) {
+
+		if (model == null) {
+			return StringBundler.concat(
+				_ctDisplayRendererRegistry.getTypeName(
+					locale, modelClassNameId),
+				StringPool.SPACE, modelClassPK);
+		}
+
+		return _ctDisplayRendererRegistry.getTitle(
+			ctCollectionId, ctSQLMode, locale, model, modelClassNameId);
+	}
+
 	private <T extends BaseModel<T>> boolean _isSite(T model) {
 		if (model instanceof Group) {
 			Group group = (Group)model;
@@ -643,10 +659,11 @@ public class ViewChangesDisplayContext {
 					"modelKey", modelInfo._modelKey
 				).put(
 					"title",
-					_ctDisplayRendererRegistry.getTitle(
+					_getTitle(
 						CTConstants.CT_COLLECTION_ID_PRODUCTION,
 						CTSQLModeThreadLocal.CTSQLMode.DEFAULT,
-						_themeDisplay.getLocale(), model, modelClassNameId)
+						_themeDisplay.getLocale(), model, modelClassNameId,
+						classPK)
 				);
 
 				modelInfo._site = _isSite(model);
@@ -712,9 +729,9 @@ public class ViewChangesDisplayContext {
 						true)
 				).put(
 					"title",
-					_ctDisplayRendererRegistry.getTitle(
+					_getTitle(
 						ctCollectionId, ctSQLMode, _themeDisplay.getLocale(),
-						model, modelClassNameId)
+						model, modelClassNameId, classPK)
 				).put(
 					"userId", ctEntry.getUserId()
 				);


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-122910>

**Notes:**
The `NullPointerException` comes from the following places in `CTDisplayRendererRegistry.java`:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java#L274-L275>
- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java#L284-L286>

The exception occurs because it is possible for the variable `model` to be `null`. Thus, we need to check when `model` is `null` and create a default title message. For creating the title when the `model` is `null`, I used the following code in `CTDisplayRendererRegistry.java`:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/CTDisplayRendererRegistry.java#L237-L241>

Let me know if you have any questions or thoughts.