### PR TITLE
LPS-123194 Message Board messages are not listed as an "Associated Asset Type" when creating a Vocabulary

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRendererFactory.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRendererFactory.java
@@ -52,7 +52,6 @@ public class MBMessageAssetRendererFactory
 	public static final String TYPE = "message";
 
 	public MBMessageAssetRendererFactory() {
-		setCategorizable(false);
 		setLinkable(true);
 		setPortletId(MBPortletKeys.MESSAGE_BOARDS);
 		setSearchable(true);


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-123194>

**Notes:**
Currently, it is not possible to create a vocabulary that is exclusive for MB threads/messages. Specifically, when creating a new vocabulary and selecting an "Associated Asset Type", MB threads/messages are not available as a selection. This is considered a missing feature since MB threads can be associated with a vocabulary's category (see [LPS-108886](https://issues.liferay.com/browse/LPS-108886)). For further context, please see [PTR-2051](https://issues.liferay.com/browse/PTR-2051).

As seen [here](https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRendererFactory.java#L55), the portal explicitly sets MB messages as not categorizable. Thus, the solution is to simply remove this line of code.

Let me know if you have any questions or thoughts.