### PR TITLE
LPS-128854 Display error toast when rating after the session expires

### DIFF
--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/Ratings.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/Ratings.js
@@ -49,6 +49,14 @@ const Ratings = ({
 
 	const sendVoteRequest = useCallback(
 		(score) => {
+			if ('expired' === Liferay.Session.get('sessionState')) {
+				errorToast(
+					`${Liferay.Language.get('you-must-be-signed-in-to-rate')}`
+				);
+
+				return Promise.resolve();
+			}
+
 			Liferay.fire('ratings:vote', {
 				className,
 				classPK,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-128854

According to this [comment](https://issues.liferay.com/browse/PTR-2286?focusedCommentId=2388731&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2388731) on [PTR-2286](https://issues.liferay.com/browse/PTR-2286), when a user session is inactive, users should not be allowed to add or remove ratings.

**Issue:**  Rating after the session expires performs a fetch that results in the following error: `SyntaxError: Unexpected token < in JSON at position 47`. The exception is caught and the error toast is displayed with the default error message. See https://github.com/liferay/liferay-portal/blob/e4e10a9fdcb2272efc3789d564e96e87dbead813/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/Ratings.js#L67-L74

**Solution:** Avoid fetching if the session is expired, and display a descriptive error message (reused from [LPS-75593](https://issues.liferay.com/browse/LPS-75593)) that informs the user to sign in to rate.