### PR TITLE
LPS-137215

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1079,7 +1079,7 @@ public class ServicePreAction extends Action {
 				viewableStaging = true;
 			}
 
-			if(layout.isPrivateLayout() && !signedIn){
+			if (layout.isPrivateLayout() && !signedIn) {
 				loginRequest = true;
 			}
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1079,6 +1079,10 @@ public class ServicePreAction extends Action {
 				viewableStaging = true;
 			}
 
+			if(layout.isPrivateLayout() && !signedIn){
+				loginRequest = true;
+			}
+
 			if (viewableStaging) {
 				layouts = LayoutLocalServiceUtil.getLayouts(
 					layout.getGroupId(), layout.isPrivateLayout(),


### PR DESCRIPTION
The previous behavior when trying to access a private page as a non-logged in user caused a response of _Not Found_. Adding a conditional right before the permission verification to make to user go to the sign in screen solved the issue.