### PR TITLE
LPS-136040

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -170,31 +170,15 @@ public class AssetTagsSelectorTag extends IncludeTag {
 	}
 
 	protected long[] getGroupIds() {
-		if (_groupIds != null) {
-			return _groupIds;
-		}
-
 		HttpServletRequest httpServletRequest = getRequest();
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		long[] groupIds = null;
+		long[] groupIds = {};
 
-		Group group = themeDisplay.getScopeGroup();
-
-		if (group.isLayout()) {
-			groupIds = new long[] {group.getParentGroupId()};
-		}
-		else {
-			groupIds = new long[] {group.getGroupId()};
-		}
-
-		if (group.getParentGroupId() != themeDisplay.getCompanyGroupId()) {
-			groupIds = ArrayUtil.append(
-				groupIds, themeDisplay.getCompanyGroupId());
-		}
+		groupIds = ArrayUtil.append(groupIds, themeDisplay.getCompanyGroupId());
 
 		return groupIds;
 	}
@@ -227,7 +211,7 @@ public class AssetTagsSelectorTag extends IncludeTag {
 
 			if (_groupIds != null) {
 				portletURL.setParameter(
-					"groupIds", StringUtil.merge(_groupIds, StringPool.COMMA));
+					"groupIds", StringUtil.merge(getGroupIds(), StringPool.COMMA));
 			}
 
 			portletURL.setParameter("eventName", getEventName());


### PR DESCRIPTION
The previous behavior forced the Control Panel group id to be used, because it was stored before the getGroupIds() was called. In addition, the portlet URL's parameter "groupIds" was using that id which led the Selector fetch no tag. A piece of code was removed because it made the fetch use the Site id.