### PR TITLE
LPS-136040

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -17,12 +17,10 @@ package com.liferay.asset.taglib.servlet.taglib;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagServiceUtil;
 import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
-import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
@@ -179,13 +177,11 @@ public class AssetTagsSelectorTag extends IncludeTag {
 
 		try {
 			if (ArrayUtil.isEmpty(_groupIds)) {
-				return PortalUtil.
-					getCurrentAndAncestorSiteGroupIds(
-						themeDisplay.getScopeGroupId());
+				return PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					themeDisplay.getScopeGroupId());
 			}
 
-			return PortalUtil.
-				getCurrentAndAncestorSiteGroupIds(_groupIds);
+			return PortalUtil.getCurrentAndAncestorSiteGroupIds(_groupIds);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -224,7 +220,8 @@ public class AssetTagsSelectorTag extends IncludeTag {
 
 			if (_groupIds != null) {
 				portletURL.setParameter(
-					"groupIds", StringUtil.merge(getGroupIds(), StringPool.COMMA));
+					"groupIds",
+					StringUtil.merge(getGroupIds(), StringPool.COMMA));
 			}
 
 			portletURL.setParameter("eventName", getEventName());

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -17,6 +17,7 @@ package com.liferay.asset.taglib.servlet.taglib;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagServiceUtil;
 import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -170,33 +171,29 @@ public class AssetTagsSelectorTag extends IncludeTag {
 	}
 
 	protected long[] getGroupIds() {
-		if (_groupIds != null) {
-			return _groupIds;
-		}
-
 		HttpServletRequest httpServletRequest = getRequest();
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		long[] groupIds = null;
+		try {
+			if (ArrayUtil.isEmpty(_groupIds)) {
+				return PortalUtil.
+					getCurrentAndAncestorSiteGroupIds(
+						themeDisplay.getScopeGroupId());
+			}
 
-		Group group = themeDisplay.getScopeGroup();
-
-		if (group.isLayout()) {
-			groupIds = new long[] {group.getParentGroupId()};
+			return PortalUtil.
+				getCurrentAndAncestorSiteGroupIds(_groupIds);
 		}
-		else {
-			groupIds = new long[] {group.getGroupId()};
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
 		}
 
-		if (group.getParentGroupId() != themeDisplay.getCompanyGroupId()) {
-			groupIds = ArrayUtil.append(
-				groupIds, themeDisplay.getCompanyGroupId());
-		}
-
-		return groupIds;
+		return new long[0];
 	}
 
 	protected String getId() {
@@ -227,7 +224,7 @@ public class AssetTagsSelectorTag extends IncludeTag {
 
 			if (_groupIds != null) {
 				portletURL.setParameter(
-					"groupIds", StringUtil.merge(_groupIds, StringPool.COMMA));
+					"groupIds", StringUtil.merge(getGroupIds(), StringPool.COMMA));
 			}
 
 			portletURL.setParameter("eventName", getEventName());


### PR DESCRIPTION
The previous behavior forced the Control Panel group id to be used, because it was stored before the getGroupIds() was called, using the same logic of the Categories Selector did the trick. But, in addition, the portlet URL's parameter "groupIds" was using that id which led the Selector fetch no tag. 