### PR TITLE
LPS-139497

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
@@ -124,7 +124,6 @@ const TransLateActionBar = ({
 								<ClayButton
 									disabled={saveButtonDisabled}
 									displayType="secondary"
-									onClick={onSaveButtonClick}
 									small
 									type="submit"
 								>
@@ -133,6 +132,7 @@ const TransLateActionBar = ({
 								<ClayButton
 									disabled={publishButtonDisabled}
 									displayType="primary"
+									onClick={onSaveButtonClick}
 									small
 									type="submit"
 								>


### PR DESCRIPTION
When creating/editing the translation of a site, the Save Draft button and Publish button had exchanged their behaviors.

Step to reproduce:

1. Add content page and publish.
2. Go to Site builder -> Pages
3. on page settings select Translate
4. Translate the page to any language and Publish.

# What have been changed?

Now when clicking on Save Draft, it does save the translation as a draft. When clicking on the Publish button, it now publishes the translation.

# Why this fix was necessary?

The previous behavior made the Save Button and Publish have incorrect behaviors, exchanging their behaviors.

Gif of the current behavior.


![translation](https://user-images.githubusercontent.com/35113296/136611211-02e11c3a-2784-4215-a4a5-ac5e75890954.gif)
