### PR TITLE
LPS-140333

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPalette.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPalette.js
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import classNames from 'classnames';
+import {capitalize} from 'data-engine-js-components-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -53,6 +54,7 @@ export default function ColorPalette({
 								displayType="unstyled"
 								onClick={(event) => onColorSelect(color, event)}
 								small
+								title={capitalize(color)}
 							/>
 						</li>
 					))}


### PR DESCRIPTION
The Color Palette had no tooltip when the user hovered the mouse over the colors, making it hard the for him to distinguish the colors.

# What has been changed?

When hovering the mouse over the colors of the Color Palette, a tooltip the color name is shown.

# Why this change was necessary?

A lack of tooltip affected the UX for the user didn't know the color name.

More details at [LPS-140333](https://issues.liferay.com/browse/LPS-140333)

![image](https://user-images.githubusercontent.com/35113296/136785290-0c8ab439-a173-430b-b8cd-aa6fec6a8bc1.png)
