### PR TITLE
[TECHNICAL SUPPORT] FrontEnd debug prompt Fixed issue where was impossible to scroll on left side of screen

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -192,7 +192,7 @@ $productMenuWidth: 320px;
 				max-height: calc(
 					100vh - #{$controlMenuHeight + $portletLayoutMargin} - #{$toolbarHeight}
 				);
-				overflow: auto;
+				
 
 				@include media-breakpoint-up(lg) {
 					max-height: calc(


### PR DESCRIPTION
The issue was, when accessing Content and Data > Web Content > Structures tab and adding enough fields for the structure becomes scrollable, it was impossible to scroll in the left side of the screen. This was caused by a `overflow: auto`. I just removed the overflow so the scrollable area could be in the entire screen.  