### PR TITLE
LPS-183708 - review suggestions

### DIFF
--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -142,13 +142,12 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = "";
+			String languageId = StringPool.BLANK;
 
-			int start = path.length() + name.length() + 2;
-			int end = urlPath.length() - ".properties".length();
-
-			if (start < end) {
-				languageId = urlPath.substring(start, end);
+			if (urlPath.contains(StringPool.UNDERLINE)) {
+				languageId = urlPath.substring(
+					path.length() + name.length() + 2,
+					urlPath.length() - ".properties".length());
 			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -131,7 +131,7 @@ public class LanguageResourcesExtender
 		}
 
 		Enumeration<URL> enumeration = bundle.findEntries(
-			path, name.concat("_*.properties"), false);
+			path, name.concat("*.properties"), false);
 
 		if (enumeration == null) {
 			return;
@@ -142,9 +142,14 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = urlPath.substring(
-				path.length() + name.length() + 2,
-				urlPath.length() - ".properties".length());
+			String languageId = "";
+
+			int start = path.length() + name.length() + 2;
+			int end = urlPath.length() - ".properties".length();
+
+			if (start < end) {
+				languageId = urlPath.substring(start, end);
+			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -63,6 +63,41 @@ public class LanguageResourcesTest {
 	}
 
 	@Test
+	public void testLanguageResource() {
+		String key = "year";
+
+		String defaultValue = _language.get(new Locale("", ""), key);
+		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
+
+		Locale defaultLocale = LocaleUtil.FRANCE;
+
+		LocaleUtil.setDefault(
+			defaultLocale.getLanguage(), defaultLocale.getCountry(),
+			defaultLocale.getVariant());
+
+		Assert.assertEquals(
+			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
+
+		Locale locale = new Locale("ps", "AF");
+
+		_serviceRegistration1 = _bundleContext.registerService(
+			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
+			HashMapDictionaryBuilder.<String, Object>put(
+				Constants.SERVICE_RANKING, 0
+			).put(
+				"language.id", _language.getLanguageId(locale)
+			).build());
+
+		Assert.assertEquals(
+			_VALUE_1,
+			_language.get(locale, TestResourceBundle.class.getName(), null));
+		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
+
+		LocaleUtil.setDefault(
+			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
+	}
+
+	@Test
 	public void testLanguageResourceServiceTrackerCustomizer() {
 		_assertValue(null);
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -66,7 +66,7 @@ public class LanguageResourcesTest {
 	public void testLanguageResource() {
 		String key = "year";
 
-		String expectedTranslation = _language.get(new Locale("", ""), key);
+		String expectedTranslation = "Year";
 
 		Assert.assertEquals(
 			expectedTranslation, _language.get(_locale, key, null));
@@ -134,7 +134,7 @@ public class LanguageResourcesTest {
 	public void testLanguageResourceUsingSupportedLocale() {
 		String key = "year";
 
-		String expectedTranslation = _language.get(LocaleUtil.FRANCE, key);
+		String expectedTranslation = "Année";
 
 		Locale locale = LocaleUtil.FRANCE;
 
@@ -146,8 +146,7 @@ public class LanguageResourcesTest {
 	public void testLanguageResourceUsingUnsupportedLocale() {
 		String key = "year";
 
-		String expectedBaseLanguagePropertiesTranslation = _language.get(
-			new Locale("", ""), key);
+		String expectedBaseLanguagePropertiesTranslation = "Year";
 
 		Locale locale = new Locale("ps", "AF");
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -67,35 +67,8 @@ public class LanguageResourcesTest {
 		String key = "year";
 
 		String defaultValue = _language.get(new Locale("", ""), key);
-		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
 
-		Locale defaultLocale = LocaleUtil.FRANCE;
-
-		LocaleUtil.setDefault(
-			defaultLocale.getLanguage(), defaultLocale.getCountry(),
-			defaultLocale.getVariant());
-
-		Assert.assertEquals(
-			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
-
-		LocaleUtil.setDefault(
-			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
-
-		Locale locale = new Locale("ps", "AF");
-
-		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
-
-		_serviceRegistration1 = _bundleContext.registerService(
-			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
-			HashMapDictionaryBuilder.<String, Object>put(
-				Constants.SERVICE_RANKING, 0
-			).put(
-				"language.id", _language.getLanguageId(locale)
-			).build());
-
-		Assert.assertEquals(
-			_VALUE_1,
-			_language.get(locale, TestResourceBundle.class.getName(), null));
+		Assert.assertEquals(defaultValue, _language.get(_locale, key, null));
 	}
 
 	@Test
@@ -154,6 +127,40 @@ public class LanguageResourcesTest {
 		_serviceRegistration1 = _unregister(_serviceRegistration1);
 
 		_assertValue(null);
+	}
+
+	@Test
+	public void testLanguageResourceUsingSupportedLocale() {
+		String key = "year";
+
+		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
+
+		Locale locale = LocaleUtil.FRANCE;
+
+		Assert.assertEquals(frenchValue, _language.get(locale, key, null));
+	}
+
+	@Test
+	public void testLanguageResourceUsingUnsupportedLocale() {
+		String key = "year";
+
+		String defaultValue = _language.get(new Locale("", ""), key);
+
+		Locale locale = new Locale("ps", "AF");
+
+		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
+
+		_serviceRegistration1 = _bundleContext.registerService(
+			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
+			HashMapDictionaryBuilder.<String, Object>put(
+				Constants.SERVICE_RANKING, 0
+			).put(
+				"language.id", _language.getLanguageId(locale)
+			).build());
+
+		Assert.assertEquals(
+			_VALUE_1,
+			_language.get(locale, TestResourceBundle.class.getName(), null));
 	}
 
 	private void _assertValue(String expectedValue) {

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -70,6 +70,10 @@ public class LanguageResourcesTest {
 
 		Assert.assertEquals(
 			expectedTranslation, _language.get(_locale, key, null));
+
+		_serviceRegistration1 = _register(_VALUE_1, 0, _languageId);
+
+		_assertValue(_VALUE_1, _locale);
 	}
 
 	@Test
@@ -140,6 +144,11 @@ public class LanguageResourcesTest {
 
 		Assert.assertEquals(
 			expectedTranslation, _language.get(locale, key, null));
+
+		_serviceRegistration1 = _register(
+			_VALUE_1, 0, _language.getLanguageId(locale));
+
+		_assertValue(_VALUE_1, locale);
 	}
 
 	@Test

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -154,32 +154,35 @@ public class LanguageResourcesTest {
 			expectedBaseLanguagePropertiesTranslation,
 			_language.get(locale, key, null));
 
-		_serviceRegistration1 = _bundleContext.registerService(
-			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
-			HashMapDictionaryBuilder.<String, Object>put(
-				Constants.SERVICE_RANKING, 0
-			).put(
-				"language.id", _language.getLanguageId(locale)
-			).build());
+		_serviceRegistration1 = _register(
+			_VALUE_1, 0, _language.getLanguageId(locale));
 
-		Assert.assertEquals(
-			_VALUE_1,
-			_language.get(locale, TestResourceBundle.class.getName(), null));
+		_assertValue(_VALUE_1, locale);
 	}
 
 	private void _assertValue(String expectedValue) {
+		_assertValue(expectedValue, _locale);
+	}
+
+	private void _assertValue(String expectedValue, Locale locale) {
 		Assert.assertEquals(
 			expectedValue,
-			_language.get(_locale, TestResourceBundle.class.getName(), null));
+			_language.get(locale, TestResourceBundle.class.getName(), null));
 	}
 
 	private ServiceRegistration<?> _register(String value, int serviceRanking) {
+		return _register(value, serviceRanking, _languageId);
+	}
+
+	private ServiceRegistration<?> _register(
+		String value, int serviceRanking, String languageId) {
+
 		return _bundleContext.registerService(
 			ResourceBundle.class, new TestResourceBundle(value),
 			HashMapDictionaryBuilder.<String, Object>put(
 				Constants.SERVICE_RANKING, serviceRanking
 			).put(
-				"language.id", _languageId
+				"language.id", languageId
 			).build());
 	}
 

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -66,9 +66,10 @@ public class LanguageResourcesTest {
 	public void testLanguageResource() {
 		String key = "year";
 
-		String defaultValue = _language.get(new Locale("", ""), key);
+		String expectedTranslation = _language.get(new Locale("", ""), key);
 
-		Assert.assertEquals(defaultValue, _language.get(_locale, key, null));
+		Assert.assertEquals(
+			expectedTranslation, _language.get(_locale, key, null));
 	}
 
 	@Test
@@ -133,22 +134,26 @@ public class LanguageResourcesTest {
 	public void testLanguageResourceUsingSupportedLocale() {
 		String key = "year";
 
-		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
+		String expectedTranslation = _language.get(LocaleUtil.FRANCE, key);
 
 		Locale locale = LocaleUtil.FRANCE;
 
-		Assert.assertEquals(frenchValue, _language.get(locale, key, null));
+		Assert.assertEquals(
+			expectedTranslation, _language.get(locale, key, null));
 	}
 
 	@Test
 	public void testLanguageResourceUsingUnsupportedLocale() {
 		String key = "year";
 
-		String defaultValue = _language.get(new Locale("", ""), key);
+		String expectedBaseLanguagePropertiesTranslation = _language.get(
+			new Locale("", ""), key);
 
 		Locale locale = new Locale("ps", "AF");
 
-		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
+		Assert.assertEquals(
+			expectedBaseLanguagePropertiesTranslation,
+			_language.get(locale, key, null));
 
 		_serviceRegistration1 = _bundleContext.registerService(
 			ResourceBundle.class, new TestResourceBundle(_VALUE_1),

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -78,7 +78,12 @@ public class LanguageResourcesTest {
 		Assert.assertEquals(
 			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
 
+		LocaleUtil.setDefault(
+			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
+
 		Locale locale = new Locale("ps", "AF");
+
+		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
 
 		_serviceRegistration1 = _bundleContext.registerService(
 			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
@@ -91,10 +96,6 @@ public class LanguageResourcesTest {
 		Assert.assertEquals(
 			_VALUE_1,
 			_language.get(locale, TestResourceBundle.class.getName(), null));
-		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
-
-		LocaleUtil.setDefault(
-			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
 	}
 
 	@Test


### PR DESCRIPTION
Previous PR: https://github.com/ericyanLr/liferay-portal/pull/309

Hi @wanderlast,

I decided to provide feedback via a separate PR, figured it would be easier this way.

**Regarding:**

> Used a different key than "Liferay" since I realized that "Liferay" is something we don't actually localize so it'd be the same in basically all languages. 😅 I arbitrarily chose the word "Year" instead.

That makes sense to me.

**Regarding:**

> Added some logic to change the default locale. This is since we want to make sure we're grabbing from language.properties instead of the default locale (which is the current behavior). If we keep the default locale as EN-US (which I'm assuming is the default on the test instances), we won't actually see any difference between default locale and language.properties. 

I think we can just rely on the assertion portion and specify a specific locale (`_language.get(locale, key, null)`), to verify we are grabbing the translation from the proper Language_*.properties file, at least for like the fr_FR example.

Though for the custom locale, like the ps_AF example, it may not be as clear on whether it's taking it from the default locale or the base language.properties.
- From my understanding though, with this fix, the translation would be taken from the base language.properties file, not from the default locale.
  - If we breakpoint: `testLanguageResourceUsingUnsupportedLocale` where it calls: `_language.get(locale, key, null)`
  - We can see in [LanguageResources.java#L59C2-L80](https://github.com/liferay/liferay-portal/blob/7.4.13-u86/portal-impl/src/com/liferay/portal/language/LanguageResources.java#L59C2-L80) it first attempts to retrieve with `ps_AF`
  - It fails and attempts again here: [LanguageResources.java#L83](https://github.com/liferay/liferay-portal/blob/7.4.13-u86/portal-impl/src/com/liferay/portal/language/LanguageResources.java#L83) to retrieve with `ps`
  - It fails and attempts again here: [LanguageResources.java#L83](https://github.com/liferay/liferay-portal/blob/7.4.13-u86/portal-impl/src/com/liferay/portal/language/LanguageResources.java#L83) to retrieve with `(blank string)`, which with our fix, introduces the base Language.properties file when a (blank string) is used for the languageId.

----

This PR just shows suggestions I had regarding your test case.

Also, feel free to combine it however you like or to discard it, these are just suggestions and I separated them into many commits to kinda show my thought process.

- I tried to make it test the same thing as your original test case and thought it could be easier to understand if we split it up into multiple test cases.
- I also tried to avoid changing the default locale, in case it for some reason introduces issues to other tests.

Feel free to let me know if you have any questions.
Hope this helps!